### PR TITLE
QA-12513: Updated background and font colors of settings headers

### DIFF
--- a/src/main/resources/css/settings/style.css
+++ b/src/main/resources/css/settings/style.css
@@ -29,21 +29,20 @@ table .radio {
 
 
 #siteSettings .page-header {
-    color: #fff;
+    color: #393B3C;
     height: 64px;
     line-height: 64px;
     margin: 0 -15px;
     margin-bottom: 16px;
     padding-bottom: 0;
-    /*background: #546E7A;*/
-    background: #3B3D40;
+    background: #fff;
 }
 
 #siteSettings .page-header h2 {
     margin: 0;
     padding: 0;
     margin-left: 25px;
-    font-size: 20px;
+    font-size: 25px;
     line-height: 64px;
     width: 80%;
     white-space: nowrap;


### PR DESCRIPTION
## JIRA
https://jira.jahia.org/browse/QA-12513

## Description
Invert the color of the site and server settings header for Jahia 8.0, to use
- #fff for the background
- #393B3C for the police
- font-size: 25px for the title

## Tests

The following are included in this PR
- [ ] Unit Tests (Most changes _should_ have unit tests)
- [ ] Integration Tests

## Checklist

<!-- 
This section contains a set of non-automated checks, it is there to remind you to think about some business critical topics. 
If some are not applicable they could simply be deleted deleted.
If you need to provide more details, please use the description section.
-->

I have considered the following implications of my change: 

- [ ] Security (in particular for changes to authentication, authorization, data fetching, ...)
- [ ] Performance
- [ ] Migration
- [ ] Code maintainability

## Documentation

<!-- 
Indicate if you have been writing documentation has part of this change.
-->

- [ ] Inline documentation
- [ ] Internal Documentation (wiki)
- [ ] User-facing Documentation
