### PR TITLE
BACKLOG-12935: reorerding of the server settings

### DIFF
--- a/src/javascript/registrations/groups/registerRoutes.js
+++ b/src/javascript/registrations/groups/registerRoutes.js
@@ -4,9 +4,9 @@ import React from 'react';
 
 export const registerRoutes = function () {
     registry.add('adminRoute', 'manageGroups', {
-        targets: ['administration-server-usersAndRoles:1'],
+        targets: ['administration-server-usersAndRoles:20'],
         requiredPermission: 'adminGroups',
-        icon: <Group/>,
+        icon: null,
         label: 'siteSettings:groups.label',
         isSelectable: true,
         iframeUrl: window.contextJsParameters.contextPath + '/cms/adminframe/default/$lang/settings.manageGroups.html'

--- a/src/javascript/registrations/users/registerRoutes.js
+++ b/src/javascript/registrations/users/registerRoutes.js
@@ -4,9 +4,9 @@ import React from 'react';
 
 export const registerRoutes = function () {
     registry.add('adminRoute', 'manageUsers', {
-        targets: ['administration-server-usersAndRoles:4'],
+        targets: ['administration-server-usersAndRoles:10'],
         requiredPermission: 'adminUsers',
-        icon: <Person/>,
+        icon: null,
         label: 'siteSettings:users.label',
         isSelectable: true,
         iframeUrl: window.contextJsParameters.contextPath + '/cms/adminframe/default/$lang/settings.manageUsers.html'


### PR DESCRIPTION
## JIRA

https://jira.jahia.org/browse/BACKLOG-12935

## Description

Reordered the server settings (here users and group entries) + removed user and groups icons in server administration (we need them only for site administration)

## Tests

The following are included in this PR
- [ ] Unit Tests (Most changes _should_ have unit tests)
- [ ] Integration Tests

## Checklist

I have considered the following implications of my change: 
it's just a reordering, nothing special here.

- [ ] Security (in particular for changes to authentication, authorization, data fetching, ...)
- [ ] Performance
- [ ] Migration
- [ ] Code maintainability

## Documentation

- [ ] Inline documentation
- [ ] Internal Documentation (wiki)
- [ ] User-facing Documentation
