### PR TITLE
Prevent matrix jobs from having the same artifact name

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -37,6 +37,7 @@ jobs:
           should_skip_testrail: false
           should_skip_zencrepes: false
           github_artifact_name: siteSettings-tests-artifacts-${{ strategy.job-index }}-${{ github.run_number }}
+          jahia_artifact_name: siteSettings-tests-artifacts-${{ strategy.job-index }}-${{ github.run_number }}
           bastion_ssh_private_key: ${{ secrets.BASTION_SSH_PRIVATE_KEY_JAHIACI }}
           jahia_license: ${{ secrets.JAHIA_LICENSE_8X_FULL }}
           docker_username: ${{ secrets.DOCKERHUB_USERNAME }}


### PR DESCRIPTION
Without this change, artifacts on Jahia servers have the same name.