### PR TITLE
TECH-1488: Fixed incorrect provisioning script

### DIFF
--- a/.github/workflows/nightly-jahiaRelease.yml
+++ b/.github/workflows/nightly-jahiaRelease.yml
@@ -25,7 +25,7 @@ jobs:
           incident_service: siteSettings-JahiaRL
           timeout_minutes: 20
           testrail_project: Site Settings Module
-          tests_manifest: provisioning-manifest-81x.yml
+          tests_manifest: provisioning-manifest-snapshot.yml
           jahia_image: jahia/jahia-ee:8
           should_use_build_artifacts: false
           should_skip_artifacts: true


### PR DESCRIPTION
Since we're testing on 8.2.0.3+ releases, we need to use the dependencies corresponding to the snapshot version of the module.
This should fix this error: https://github.com/Jahia/siteSettings/actions/runs/9310731971
