### PR TITLE
QA-15279: Show context menu for page models

### DIFF
--- a/src/javascript/registrations/jcontent/registerRoutes.js
+++ b/src/javascript/registrations/jcontent/registerRoutes.js
@@ -8,6 +8,6 @@ export const registerRoutes = function () {
         icon: <WebPage/>,
         label: 'siteSettings:models.label',
         isSelectable: true,
-        iframeUrl: window.contextJsParameters.contextPath + '/cms/editframe/default/$lang/sites/$site-key.page-models.html'
+        iframeUrl: window.contextJsParameters.contextPath + '/cms/edit/default/$lang/sites/$site-key.page-models.html?redirect=false&fullscreen=true'
     });
 };


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

https://jira.jahia.org/browse/QA-15279

## Description

Show context menu (right-click) for page models that was present in Jahia 7.x but is no longer present in Jahia 8.x.

### Details
The easy solution is to load the GWT page used in Jahia 7.x (with a functional context menu) as an Iframe and use the special parameters `redirect=false` and `fullscreen=true` to respectively prevent the redirect towards a Jcontent page and to display the page without the left navigation menu.
A cleaner (but more complex) solution would be to rewrite this page as a React page and use the `DisplayActions` React component.