### PR TITLE
test: fix Testrail project name

### DIFF
--- a/.github/workflows/manual-run.yml
+++ b/.github/workflows/manual-run.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: jahia/jahia-modules-action/integration-tests@v2
         with:
           module_id: siteSettings
-          testrail_project: Site Settings Module
+          testrail_project: Site Settings
           jahia_image: ${{ github.event.inputs.jahia_image }}
           should_use_build_artifacts: false
           should_skip_artifacts: true

--- a/.github/workflows/nightly-jahiaRelease.yml
+++ b/.github/workflows/nightly-jahiaRelease.yml
@@ -24,7 +24,7 @@ jobs:
           module_id: siteSettings
           incident_service: siteSettings-JahiaRL
           timeout_minutes: 20
-          testrail_project: Site Settings Module
+          testrail_project: Site Settings
           tests_manifest: provisioning-manifest-snapshot.yml
           jahia_image: jahia/jahia-ee:8
           should_use_build_artifacts: false

--- a/.github/workflows/nightly-jahiaSnapshot.yml
+++ b/.github/workflows/nightly-jahiaSnapshot.yml
@@ -24,7 +24,7 @@ jobs:
           module_id: siteSettings
           incident_service: siteSettings-JahiaSN
           timeout_minutes: 20
-          testrail_project: Site Settings Module
+          testrail_project: Site Settings
           tests_manifest: provisioning-manifest-snapshot.yml
           jahia_image: jahia/jahia-ee-dev:8-SNAPSHOT
           should_use_build_artifacts: false

--- a/.github/workflows/on-code-change.yml
+++ b/.github/workflows/on-code-change.yml
@@ -84,7 +84,7 @@ jobs:
       - uses: jahia/jahia-modules-action/integration-tests@v2
         with:
           module_id: siteSettings
-          testrail_project: Site Settings Module
+          testrail_project: Site Settings
           tests_manifest: provisioning-manifest-build.yml
           jahia_image: jahia/jahia-ee-dev:8-SNAPSHOT
           should_use_build_artifacts: true

--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -77,7 +77,7 @@ jobs:
       - uses: jahia/jahia-modules-action/integration-tests@v2
         with:
           module_id: siteSettings
-          testrail_project: Site Settings Module
+          testrail_project: Site Settings
           tests_manifest: provisioning-manifest-build.yml
           jahia_image: jahia/jahia-ee-dev:8-SNAPSHOT
           should_use_build_artifacts: true


### PR DESCRIPTION
## Description

Fixed the project name in Testrail.
We did not get the tests report because of the wrong name.