### PR TITLE
feat: Invalid user sessions when an account is locked

### DIFF
--- a/src/main/java/org/jahia/modules/sitesettings/users/UsersFlowHandler.java
+++ b/src/main/java/org/jahia/modules/sitesettings/users/UsersFlowHandler.java
@@ -309,6 +309,7 @@ public class UsersFlowHandler implements Serializable {
                     }
                     if (!readOnlyProps.contains("j:accountLocked")) {
                         hasErrors |= !setUserProperty("j:accountLocked", userProperties.getAccountLocked().toString(), "accountLocked", context, jahiaUser);
+                         hasErrors |= !setUserProperty("j:invalidateSessionTime", String.valueOf(new Date().getTime()), "accountLocked", context, jahiaUser);
                     }
                     if (!readOnlyProps.contains("preferredLanguage")) {
                         hasErrors |= !setUserProperty("preferredLanguage", userProperties.getPreferredLanguage().toString(), "preferredLanguage", context, jahiaUser);


### PR DESCRIPTION
When a user account is locked, set a timestamp to the current date to invalidate any opened session 