### PR TITLE
fix: Remove fragment warning

### DIFF
--- a/src/javascript/registrations/properties/SiteProperties/SiteProperties.gql-queries.js
+++ b/src/javascript/registrations/properties/SiteProperties/SiteProperties.gql-queries.js
@@ -6,7 +6,7 @@ export const SITE_INFO_QUERY = gql`
         live: jcr(workspace: LIVE) {
             result:nodeByPath(path: $path) {
                 site {
-                    ...SiteInfo
+                    ...SettingsSiteInfo
                     ...NodeCacheRequiredFields
                 }
                 ...NodeCacheRequiredFields
@@ -15,14 +15,14 @@ export const SITE_INFO_QUERY = gql`
         default: jcr {
             result:nodeByPath(path: $path) {
                 site {
-                    ...SiteInfo
+                    ...SettingsSiteInfo
                     ...NodeCacheRequiredFields
                 }
                 ...NodeCacheRequiredFields
             }
         }
     }
-    fragment SiteInfo on JCRSite {
+    fragment SettingsSiteInfo on JCRSite {
         name
         displayName(language: $displayLanguage)
         defaultLanguage


### PR DESCRIPTION
### Description
Remove gql fragment warnings.
Fragments must be uniquely named.
### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
