### PR TITLE
test: fix URL in provisioning

### DIFF
--- a/tests/provisioning-manifest-build.yml
+++ b/tests/provisioning-manifest-build.yml
@@ -1,4 +1,4 @@
-- addMavenRepository: 'https://devtools.jahia.com/nexus/content/groups/internal@id=jahia-internal@snapshots'
+- addMavenRepository: 'https://devtools.jahia.com/nexus/content/groups/internal/@id=jahia-internal@snapshots'
   username: ${env:NEXUS_USERNAME}
   password: ${env:NEXUS_PASSWORD}
 

--- a/tests/provisioning-manifest-snapshot.yml
+++ b/tests/provisioning-manifest-snapshot.yml
@@ -1,4 +1,4 @@
-- addMavenRepository: 'https://devtools.jahia.com/nexus/content/groups/internal@id=jahia-internal@snapshots'
+- addMavenRepository: 'https://devtools.jahia.com/nexus/content/groups/internal/@id=jahia-internal@snapshots'
   username: ${env:NEXUS_USERNAME}
   password: ${env:NEXUS_PASSWORD}
 


### PR DESCRIPTION
### Description
After a change in httpcomponent here https://github.com/apache/httpcomponents-client/pull/624/files#diff-db78ac5f9e089dd5dfda623225323b303e24aa39bdbab1105bcb806ca5958760R65
We need to add an extra / in the URL for provisioning used on 8.2.

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
