### PR TITLE
feat: do not display inherited groups and users in user management.

### DIFF
--- a/src/main/java/org/jahia/modules/sitesettings/groups/ManageGroupsFlowHandler.java
+++ b/src/main/java/org/jahia/modules/sitesettings/groups/ManageGroupsFlowHandler.java
@@ -458,9 +458,9 @@ public class ManageGroupsFlowHandler implements Serializable {
         });
 
         Set<JCRGroupNode> groups = PrincipalViewHelper.getGroupSearchResult(null, siteKey, null, null, null, null);
-
+        List<JCRNodeWrapper> members = groupNode.getMembers();
         for (JCRGroupNode group : groups) {
-            sortedResults.put(group, groupNode.getMembers().contains(group));
+            sortedResults.put(group, members.contains(group));
         }
 
         LinkedHashMap<JahiaGroup, Boolean> results = new LinkedHashMap<>();
@@ -491,8 +491,9 @@ public class ManageGroupsFlowHandler implements Serializable {
                 searchCriteria.getProviders());
 
         // Flag current group users
+        List<JCRNodeWrapper> members = groupNode.getMembers();
         for (JCRUserNode user : users) {
-            sortedResults.put(user, groupNode.getMembers().contains(user));
+            sortedResults.put(user, members.contains(user));
         }
 
         LinkedHashMap<JahiaUser, Boolean> results = new LinkedHashMap<>();

--- a/src/main/java/org/jahia/modules/sitesettings/groups/ManageGroupsFlowHandler.java
+++ b/src/main/java/org/jahia/modules/sitesettings/groups/ManageGroupsFlowHandler.java
@@ -40,7 +40,7 @@ import java.util.*;
 
 /**
  * Web flow handler for group management actions.
- * 
+ *
  * @author Sergiy Shyrkov
  */
 public class ManageGroupsFlowHandler implements Serializable {
@@ -64,7 +64,7 @@ public class ManageGroupsFlowHandler implements Serializable {
 
     /**
      * Performs the creation of a new group for the site.
-     * 
+     *
      * @param group
      *            the group model object with the data for the new group
      * @param context
@@ -100,7 +100,7 @@ public class ManageGroupsFlowHandler implements Serializable {
 
     /**
      * Adds the specified members to the group.
-     * 
+     *
      * @param groupKey
      *            the key of the group to add members to
      * @param members
@@ -152,7 +152,7 @@ public class ManageGroupsFlowHandler implements Serializable {
 
     /**
      * Duplicates the selected group.
-     * 
+     *
      * @param selectedGroupKey
      *            the key of the group to be copied
      * @param newGroup
@@ -206,7 +206,7 @@ public class ManageGroupsFlowHandler implements Serializable {
 
     /**
      * Returns a map of all group providers currently registered.
-     * 
+     *
      * @return a map of all group providers currently registered
      */
     public Set<String> getProviders(final boolean isUsers, final boolean includeGlobals) throws RepositoryException {
@@ -222,7 +222,7 @@ public class ManageGroupsFlowHandler implements Serializable {
                     }
                     for (JCRStoreProvider provider : userManagerService.getProviderList(siteKey, session)) {
                         providerKeys.add(provider.getKey());
-                    }    
+                    }
                 } else {
                     if(includeGlobals) {
                         for (JCRStoreProvider provider : groupManagerService.getProviderList(null, session)) {
@@ -241,7 +241,7 @@ public class ManageGroupsFlowHandler implements Serializable {
 
     /**
      * Returns a set of group keys that are considered as system and cannot be deleted.
-     * 
+     *
      * @param groups
      *            the set of all groups from the search
      * @return a set of group keys that are considered as system and cannot be deleted
@@ -262,7 +262,7 @@ public class ManageGroupsFlowHandler implements Serializable {
 
     /**
      * Returns an empty (newly initialized) search criteria bean.
-     * 
+     *
      * @return an empty (newly initialized) search criteria bean
      */
     public SearchCriteria initCriteria(RequestContext ctx) {
@@ -271,7 +271,7 @@ public class ManageGroupsFlowHandler implements Serializable {
 
     /**
      * Returns an empty (newly initialized) group bean.
-     * 
+     *
      * @return an empty (newly initialized) group bean
      */
     public GroupModel initGroup(RequestContext ctx) {
@@ -289,7 +289,7 @@ public class ManageGroupsFlowHandler implements Serializable {
 
     /**
      * Looks up the specified group by key.
-     * 
+     *
      * @param selectedGroup
      *            the group key
      * @return up the specified group by key
@@ -317,7 +317,7 @@ public class ManageGroupsFlowHandler implements Serializable {
 
     /**
      * Returns the principal object for the specified key.
-     * 
+     *
      * @param memberKey
      *            the principal key
      * @return the principal object for the specified key
@@ -337,7 +337,7 @@ public class ManageGroupsFlowHandler implements Serializable {
 
     /**
      * Performs the removal of the specified groups for the site.
-     * 
+     *
      * @param selectedGroup
      *            a key of the group to be removed
      * @param context
@@ -382,7 +382,7 @@ public class ManageGroupsFlowHandler implements Serializable {
 
     /**
      * Performs the removal of the specified members from the group.
-     * 
+     *
      * @param groupKey
      *            the key of the group to remove members from
      * @param members
@@ -460,7 +460,7 @@ public class ManageGroupsFlowHandler implements Serializable {
         Set<JCRGroupNode> groups = PrincipalViewHelper.getGroupSearchResult(null, siteKey, null, null, null, null);
 
         for (JCRGroupNode group : groups) {
-            sortedResults.put(group, groupNode.isMember(group));
+            sortedResults.put(group, groupNode.getMembers().contains(group));
         }
 
         LinkedHashMap<JahiaGroup, Boolean> results = new LinkedHashMap<>();
@@ -485,13 +485,14 @@ public class ManageGroupsFlowHandler implements Serializable {
             }
         });
 
+        // Load all users, they will be displayed in the user selector for the group.
         Set<JCRUserNode> users = PrincipalViewHelper.getSearchResult(searchCriteria.getSearchIn(),
                 searchCriteria.getSiteKey(), searchCriteria.getSearchString(), searchCriteria.getProperties(), searchCriteria.getStoredOn(),
                 searchCriteria.getProviders());
 
-        String groupName = groupNode.getName();
+        // Flag current group users
         for (JCRUserNode user : users) {
-            sortedResults.put(user, user.isMemberOfGroup(siteKey, groupName));
+            sortedResults.put(user, groupNode.getMembers().contains(user));
         }
 
         LinkedHashMap<JahiaUser, Boolean> results = new LinkedHashMap<>();

--- a/src/main/resources/resources/JahiaSiteSettings_de.properties
+++ b/src/main/resources/resources/JahiaSiteSettings_de.properties
@@ -77,8 +77,8 @@ siteSettings.user.select.one=Bitte wählen Sie einen Benutzer aus.
 siteSettings.users.bulk.create=Mehrere Benutzer anlegen
 siteSettings.users.bulk.errors.user.already.exists=Der User {0} existiert bereits
 siteSettings.users.bulk.user.creation.successful=Benutzer <span style="font:bold;">{0}</span> wurde erfolgreich angelegt
-siteSettings.message.addRemoveUsers=Fügen Sie User zur Gruppe hinzu oder entfernen Sie diese.
-siteSettings.message.addRemoveGroups=Fügen Sie Gruppen als Untergruppen hinzu oder entfernen Sie diese.
+siteSettings.message.addRemoveUsers=Benutzer als Mitglieder Ihrer Gruppe hinzufügen/entfernen. Mitglieder von Untergruppen werden nicht aufgelistet.
+siteSettings.message.addRemoveGroups=Gruppen als Untergruppen Ihrer Gruppe hinzufügen/entfernen. Mitglieder von Untergruppen werden nicht aufgelistet.
 siteSettings.modal.title.confirmDeletetion=Löschen bestätigen
 siteSettings.users.batch.file.format=Das Dateiformat erfordert eine Kopfzeile mit zumindest diesen Spalten: j:nodename (username) und j:password. Alle weiteren unterstützten User-Eigenschaften können als weitere Werte hinzugefügt werden.<br/>Beispiel:<br/>j:nodename,j:password,j:firstName,j:lastName<br/>tobias,tobias1234,Tobias,ACME
 siteSettings.users.export.or.remove=Exportieren oder entfernen

--- a/src/main/resources/resources/JahiaSiteSettings_en.properties
+++ b/src/main/resources/resources/JahiaSiteSettings_en.properties
@@ -111,8 +111,8 @@ siteSettings.users.bulk.errors.user.skipped.password=Skipping user <span style="
 siteSettings.users.bulk.remove.switch=Toggle bulk delete mode
 siteSettings.users.bulk.user.creation.successful=Successfully created user <span style="font:bold;">{0}</span>
 siteSettings.users.found=<strong>{0}</strong> users found. The first <strong>{1}</strong> are shown. Please use the search to limit the number of results.
-siteSettings.message.addRemoveUsers=Add/Remove users as members of your group.
-siteSettings.message.addRemoveGroups=Add/Remove groups as subgroups of your group.
+siteSettings.message.addRemoveUsers=Add/Remove users as members of your group. Members of subgroups are not listed.
+siteSettings.message.addRemoveGroups=Add/Remove groups as subgroups of your group. Members of subgroups are not listed.
 siteSettings.modal.title.confirmDeletetion=Confirm deletion
 siteSettings.users.export.or.remove=Export or Remove
 label.permission.siteAdminSiteProperties.description=Access to the Site properties screen

--- a/src/main/resources/resources/JahiaSiteSettings_es.properties
+++ b/src/main/resources/resources/JahiaSiteSettings_es.properties
@@ -37,3 +37,5 @@ siteSettings.user.remove=Quitar usuarios seleccionados
 siteSettings.user.remove.successful=Quitado correctamente.
 siteSettings.user.remove.unsuccessful=No se pudo quitar al usuario.
 siteSettings.users.export.or.remove=Exportar o quitar
+siteSettings.message.addRemoveUsers=Agregar/Eliminar usuarios como miembros de su grupo. Los miembros de subgrupos no se muestran.
+siteSettings.message.addRemoveGroups=Agregar/Eliminar grupos como subgrupos de su grupo. Los miembros de subgrupos no se muestran.

--- a/src/main/resources/resources/JahiaSiteSettings_fr.properties
+++ b/src/main/resources/resources/JahiaSiteSettings_fr.properties
@@ -104,8 +104,8 @@ siteSettings.users.bulk.user.creation.successful=Utilisateur <span style="font:b
 siteSettings.users.found=<strong>{0}</strong> utilisateurs trouvés. Affichage des <strong>{1}</strong> premiers. Utilisez la recherche pour limiter le nombre de résultats.
 siteSettings.users.bulk.errors.missing.import=Vous devez spécifier un fichier d'import valide.
 jnt_template.settingsBootstrap3GoogleMaterialStyle=Settings template avec Bootstrap 3 Google Material Style
-siteSettings.message.addRemoveUsers=Ajouter/Enlever des utilisateurs comme membres du groupe.
-siteSettings.message.addRemoveGroups=Ajouter/Enlever des groupes comme sous-groupes du groupe.
+siteSettings.message.addRemoveUsers=Ajouter/Supprimer des utilisateurs en tant que membres de votre groupe. Les membres des sous-groupes ne sont pas listés.
+siteSettings.message.addRemoveGroups=Ajouter/Supprimer des groupes en tant que sous-groupes de votre groupe. Les membres des sous-groupes ne sont pas listés.
 siteSettings.modal.title.confirmDeletetion=Confirmer la suppression
 siteSettings.users.export.or.remove=Exporter ou Supprimer
 label.permission.siteAdminSiteProperties.description=Accès à l'écran des propriétés du site

--- a/src/main/resources/resources/JahiaSiteSettings_it.properties
+++ b/src/main/resources/resources/JahiaSiteSettings_it.properties
@@ -37,3 +37,5 @@ siteSettings.user.remove=Rimuovere utenti selezionati
 siteSettings.user.remove.successful=Rimosso.
 siteSettings.user.remove.unsuccessful=Impossibile rimuovere l'utente.
 siteSettings.users.export.or.remove=Esporta o Rimuovi
+siteSettings.message.addRemoveUsers=Aggiungi/Rimuovi utenti come membri del tuo gruppo. I membri dei sottogruppi non sono elencati.
+siteSettings.message.addRemoveGroups=Aggiungi/Rimuovi gruppi come sottogruppi del tuo gruppo. I membri dei sottogruppi non sono elencati.

--- a/src/main/resources/resources/JahiaSiteSettings_pt.properties
+++ b/src/main/resources/resources/JahiaSiteSettings_pt.properties
@@ -36,3 +36,5 @@ siteSettings.user.remove=Remover usuários selecionados
 siteSettings.user.remove.successful=Removido com sucesso
 siteSettings.user.remove.unsuccessful=Impossível remover usuário
 siteSettings.users.export.or.remove=Exportar ou Eemover
+siteSettings.message.addRemoveUsers=Adicionar/Remover usuários como membros do seu grupo. Membros de subgrupos não são listados.
+siteSettings.message.addRemoveGroups=Adicionar/Remover grupos como subgrupos do seu grupo. Membros de subgrupos não são listados.

--- a/tests/cypress/e2e/inheritedGroupAndUsers.test.cy.ts
+++ b/tests/cypress/e2e/inheritedGroupAndUsers.test.cy.ts
@@ -1,5 +1,5 @@
 describe('Inherited groups and users for a given group', () => {
-    before("Create users and groups", () => {
+    before('Create users and groups', () => {
         cy.executeGroovy('groovy/deleteGroups.groovy')
         cy.executeGroovy('groovy/createGroups.groovy')
     })
@@ -31,9 +31,9 @@ describe('Inherited groups and users for a given group', () => {
         // Edit users
         cy.get('button[name="_eventId_editGroupMembers"]').click()
         // Check users
-        cy.get( 'input[value$="user1"]').should('be.checked')
-        cy.get( 'input[value$="user2"]').should('be.checked')
-        cy.get( 'input[value$="user3"]').should('not.be.checked')
+        cy.get('input[value$="user1"]').should('be.checked')
+        cy.get('input[value$="user2"]').should('be.checked')
+        cy.get('input[value$="user3"]').should('not.be.checked')
         cy.get('input[value$="user4"]').should('not.be.checked')
         // Check groups
         cy.get('[data-sel-role="switchToGroupsView"]').click()

--- a/tests/cypress/e2e/inheritedGroupAndUsers.test.cy.ts
+++ b/tests/cypress/e2e/inheritedGroupAndUsers.test.cy.ts
@@ -1,0 +1,43 @@
+describe('Inherited groups and users for a given group', () => {
+    before("Create users and groups", () => {
+        cy.executeGroovy('groovy/deleteGroups.groovy')
+        cy.executeGroovy('groovy/createGroups.groovy')
+    })
+
+    it('Should not have users from inherited groups', () => {
+        cy.login()
+        // Check initial env
+        cy.visit('/cms/adminframe/default/en/settings.manageGroups.html')
+        cy.contains('a', 'groupB').click()
+        // Check users
+        cy.contains('td', 'user1').should('not.exist')
+        cy.contains('td', 'user2').should('not.exist')
+        cy.contains('td', 'user3').should('exist')
+        cy.contains('td', 'user4').should('exist')
+        cy.contains('td', 'groupB').should('not.exist')
+        cy.contains('td', 'groupC').should('exist')
+
+        // Test
+        cy.visit('/cms/adminframe/default/en/settings.manageGroups.html')
+        // Open group1
+        cy.contains('a', 'groupA').click()
+        // Check users
+        cy.contains('td', 'user1').should('exist')
+        cy.contains('td', 'user2').should('exist')
+        cy.contains('td', 'user3').should('not.exist')
+        cy.contains('td', 'user4').should('not.exist')
+        cy.contains('td', 'groupB').should('exist')
+        cy.contains('td', 'groupC').should('not.exist')
+        // Edit users
+        cy.get('button[name="_eventId_editGroupMembers"]').click()
+        // Check users
+        cy.get( 'input[value$="user1"]').should('be.checked')
+        cy.get( 'input[value$="user2"]').should('be.checked')
+        cy.get( 'input[value$="user3"]').should('not.be.checked')
+        cy.get('input[value$="user4"]').should('not.be.checked')
+        // Check groups
+        cy.get('[data-sel-role="switchToGroupsView"]').click()
+        cy.get('input[value$="groupB"]').should('be.checked')
+        cy.get('input[value$="groupC"]').should('not.be.checked')
+    })
+})

--- a/tests/cypress/fixtures/groovy/createGroups.groovy
+++ b/tests/cypress/fixtures/groovy/createGroups.groovy
@@ -1,0 +1,38 @@
+import org.jahia.services.content.JCRSessionFactory
+import org.jahia.services.content.JCRSessionWrapper
+import org.jahia.services.content.decorator.JCRGroupNode
+import org.jahia.services.content.decorator.JCRUserNode
+import org.jahia.services.usermanager.JahiaGroupManagerService
+import org.jahia.services.usermanager.JahiaUserManagerService
+import org.jahia.services.usermanager.UsersGroup
+import org.jahia.settings.SettingsBean
+
+def groupService = JahiaGroupManagerService.getInstance()
+def userService = JahiaUserManagerService.getInstance()
+def session = JCRSessionFactory.getInstance().getCurrentUserSession("default")
+Map<String, JCRUserNode> userNodes = new HashMap<>()
+Map<String, JCRGroupNode> groupNodes = new HashMap<>()
+// Add users
+["user1", "user2", "user3", "user4"].forEach {user ->
+    log.info("create user {}", user)
+    userNodes.put(user, userService.createUser(user, null, 'password', new Properties(), session))
+}
+
+// Add groups
+["groupA", "groupB", "groupC"].forEach {group ->
+    log.info("create group {}", group)
+    groupNodes.put(group, groupService.createGroup(null, group, new Properties(), false, session))
+}
+
+// Add user1 and user2 to groupA
+groupNodes.get("groupA").addMember(userNodes.get("user1"))
+groupNodes.get("groupA").addMember(userNodes.get("user2"))
+// Add user3 and user4 to groupB
+groupNodes.get("groupB").addMember(userNodes.get("user3"))
+groupNodes.get("groupB").addMember(userNodes.get("user4"))
+// Add groupB to groupA
+groupNodes.get("groupA").addMember(groupNodes.get("groupB"))
+// Add groupC to groupB
+groupNodes.get("groupB").addMember(groupNodes.get("groupC"))
+
+session.save()

--- a/tests/cypress/fixtures/groovy/deleteGroups.groovy
+++ b/tests/cypress/fixtures/groovy/deleteGroups.groovy
@@ -1,0 +1,31 @@
+import org.jahia.services.content.JCRSessionFactory
+import org.jahia.services.content.JCRSessionWrapper
+import org.jahia.services.content.decorator.JCRGroupNode
+import org.jahia.services.content.decorator.JCRUserNode
+import org.jahia.services.usermanager.JahiaGroupManagerService
+import org.jahia.services.usermanager.JahiaUserManagerService
+import org.jahia.services.usermanager.UsersGroup
+import org.jahia.settings.SettingsBean
+
+def groupService = JahiaGroupManagerService.getInstance()
+def userService = JahiaUserManagerService.getInstance()
+def session = JCRSessionFactory.getInstance().getCurrentUserSession("default")
+
+// delete users
+["user1", "user2", "user3", "user4"].forEach {user ->
+    def userPath = userService.lookup(user)?.getPath()
+    if (userPath != null) {
+        log.info("delete user {}", user)
+        userService.deleteUser(userPath, session)
+    }
+}
+
+// delete groups
+["groupA", "groupB", "groupC"].forEach {group ->
+
+    def groupPath = groupService.lookupGroup(null, group)?.getPath()
+    if (groupPath != null) {
+        log.info("delete group {}", group)
+        groupService.deleteGroup(groupPath, session)
+    }
+}


### PR DESCRIPTION
### Description
From now on, inherited groups and users are no more marked as belonging to a given group

When editing group members, now only direct members of a group are checked 

<img width="369" height="143" alt="Screenshot 2025-07-29 at 18 59 30" src="https://github.com/user-attachments/assets/e692e8ee-6f93-4273-b8d0-bf385fc6f72c" />

In this example, if *groupC* is a member of *groupB* before the changes, both were checked. Now only the belonging group is checked. 

Information panel has been updated to inform about this new behavior. 
```
Add/Remove users as members of your group. Members of subgroups are not listed.
```
Groups and users are following the same rule. 

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
