### PR TITLE
test: add cypress test 'verifies systemname of system site is readonly'

### DIFF
--- a/tests/cypress/e2e/properties.cy.ts
+++ b/tests/cypress/e2e/properties.cy.ts
@@ -1,5 +1,6 @@
 import { createSite, deleteSite } from '@jahia/cypress'
 import { SiteProperties } from '../page-object/siteProperties'
+import {SmallTextField} from "../page-object/fields";
 
 describe('Tests for site properties panel', () => {
     const siteKey = 'propertiesTestSite'
@@ -40,5 +41,14 @@ describe('Tests for site properties panel', () => {
         const siteProps = SiteProperties.visit(siteKey)
         siteProps.editLanguages()
         cy.get(`iframe[src="/cms/editframe/default/en/sites/${siteKey}.manageLanguages.html"]`).should('be.visible')
+    })
+
+    it('Verifies systemname of system site is readonly', () => {
+        const siteProps = SiteProperties.visit("systemsite");
+        cy.contains("System Site").should('be.visible');
+        const contentEditor = siteProps.edit();
+        const field = contentEditor.getField(SmallTextField, 'nt:base_ce:systemName');
+        field.get().find('input').should('have.attr', 'readonly', 'readonly');
+        contentEditor.cancel();
     })
 })


### PR DESCRIPTION
### Description
Move Selenium test "testSystemNameReadOnlyWhenNecessary" to new Cypress test "Verifies systemname of system site is readonly".
https://github.com/Jahia/jahia-private/issues/4310

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
