### PR TITLE
fix: Disable auto-filling for email and password fields

### DIFF
--- a/src/main/resources/jnt_siteSettingsManageUsers/html/siteSettingsManageUsers.flow/createUser.jsp
+++ b/src/main/resources/jnt_siteSettingsManageUsers/html/siteSettingsManageUsers.flow/createUser.jsp
@@ -60,7 +60,7 @@
                     <div class="row-fluid">
                         <div class="span4">
                             <label for="email"><fmt:message key="label.email"/></label>
-                            <input type="text" name="email" class="span12" id="email" value="${userProperties.email}">
+                            <input type="text" name="email" class="span12" id="email" value="${userProperties.email}" autocomplete="off">
                         </div>
                         <div class="span4">
                             <label for="organization"><fmt:message key="label.organization"/></label>

--- a/src/main/resources/jnt_siteSettingsManageUsers/html/siteSettingsManageUsers.settingsBootstrap3GoogleMaterialStyle.flow/createUser.jsp
+++ b/src/main/resources/jnt_siteSettingsManageUsers/html/siteSettingsManageUsers.settingsBootstrap3GoogleMaterialStyle.flow/createUser.jsp
@@ -69,7 +69,7 @@
                             <div class="col-md-6">
                                 <div class="form-group label-floating">
                                     <label class="control-label" for="email"><fmt:message key="label.email"/></label>
-                                    <input type="text" name="email" class="form-control" id="email" value="${userProperties.email}">
+                                    <input type="text" name="email" class="form-control" id="email" autocomplete="off" value="${userProperties.email}">
                                 </div>
                             </div>
                             <div class="col-md-6">
@@ -83,13 +83,13 @@
                             <div class="col-md-6">
                                 <div class="form-group label-floating">
                                     <label class="control-label" for="password"><fmt:message key="label.password"/><strong class="text-danger">*</strong></label>
-                                    <input type="password" name="password" class="form-control" id="password" value="" autocomplete="off">
+                                    <input type="password" name="password" class="form-control" id="password" value="" autocomplete="new-password">
                                 </div>
                             </div>
                             <div class="col-md-6">
                                 <div class="form-group label-floating">
                                     <label class="control-label" for="passwordConfirm"><fmt:message key="label.confirmPassword"/><strong class="text-danger">*</strong></label>
-                                    <input type="password" name="passwordConfirm" class="form-control" id="passwordConfirm" value="" autocomplete="off">
+                                    <input type="password" name="passwordConfirm" class="form-control" id="passwordConfirm" value="" autocomplete="new-password">
                                 </div>
                             </div>
                         </div>

--- a/src/main/resources/jnt_siteSettingsManageUsers/html/siteSettingsManageUsers.settingsBootstrap3GoogleMaterialStyle.flow/editUser.jsp
+++ b/src/main/resources/jnt_siteSettingsManageUsers/html/siteSettingsManageUsers.settingsBootstrap3GoogleMaterialStyle.flow/editUser.jsp
@@ -61,7 +61,7 @@
                           <div class="col-md-6">
                               <div class="form-group label-floating">
                                   <label class="control-label" for="email"><fmt:message key="label.email"/></label>
-                                  <input class="form-control" type="text" name="email" id="email" value="${userProperties.email}"${functions:contains(readOnlyProperties, 'j:email') ? ' disabled="disabled"' : ''}>
+                                  <input class="form-control" type="text" name="email" id="email" autocomplete="off" value="${userProperties.email}" ${functions:contains(readOnlyProperties, 'j:email') ? ' disabled="disabled"' : ''}>
                               </div>
                           </div>
                           <div class="col-md-6">
@@ -79,7 +79,7 @@
                               <div class="form-group label-floating">
                                   <div class="input-group">
                                       <label class="control-label" for="password"><fmt:message key="label.password"/></label>
-                                      <input class="form-control" type="password" name="password" id="password" value=""${userProperties.readOnly or userProperties.external ? ' disabled="disabled"' : ''} autocomplete="off">
+                                      <input class="form-control" type="password" name="password" id="password" value=""${userProperties.readOnly or userProperties.external ? ' disabled="disabled"' : ''} autocomplete="new-password">
                                       <span class="input-group-btn">
                                           <i class="material-icons text-info" data-toggle="tooltip" data-placement="left"
                                              title="<fmt:message key='siteSettings.user.edit.password.no.change'/>"
@@ -92,7 +92,7 @@
                               <div class="form-group label-floating">
                                   <div class="input-group">
                                       <label class="control-label" for="passwordConfirm"><fmt:message key="label.confirmPassword"/></label>
-                                      <input class="form-control" type="password" name="passwordConfirm" id="passwordConfirm" value=""${userProperties.readOnly or userProperties.external ? ' disabled="disabled"' : ''} autocomplete="off">
+                                      <input class="form-control" type="password" name="passwordConfirm" id="passwordConfirm" value=""${userProperties.readOnly or userProperties.external ? ' disabled="disabled"' : ''} autocomplete="new-password">
                                       <span class="input-group-btn">
                                           <i class="material-icons text-info" data-toggle="tooltip" data-placement="left"
                                              title="<fmt:message key='siteSettings.user.edit.password.no.change'/>"


### PR DESCRIPTION
### Description
Disable auto-filling for the email and password fields when creating/updating a user, by setting the the [`autocomplete`](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/autocomplete) attribute of those fields.

This issue happens when auto-filling feature is enabled in the browser and it contains saved credentials (username/password).

### Context

I came across this bug while working on https://github.com/Jahia/jahia-private/issues/4422.

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
