### PR TITLE
chore: fix apt update/install issue in cypress image build

### DIFF
--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,9 +1,10 @@
-FROM cypress/browsers:node-22.13.1-chrome-132.0.6834.159-1-ff-134.0.2-edge-132.0.2957.127-1
+FROM cypress/browsers:node-22.21.0-chrome-141.0.7390.107-1-ff-144.0-edge-141.0.3537.92-1
 
 ARG MAVEN_VER="3.8.1"
 ARG MAVEN_BASE_URL="https://archive.apache.org/dist/maven/maven-3"
 
-RUN apt-get update && apt-get install -y jq curl
+RUN apt-get update 
+RUN apt-get install -y jq curl
 
 RUN adduser --disabled-password jahians
 


### PR DESCRIPTION
See similar change in jahia-cypress: https://github.com/Jahia/jahia-cypress/pull/189