### PR TITLE
fix: nightly after migration to reusable workflow

### DIFF
--- a/.github/workflows/nightly-jahiaRelease.yml
+++ b/.github/workflows/nightly-jahiaRelease.yml
@@ -15,6 +15,8 @@ jobs:
       provisioning_manifest: provisioning-manifest-build.yml
       incident_service: siteSettings-JahiaRL
       jahia_image: jahia/jahia-ee:8
+      should_skip_artifacts: true
+      should_use_build_artifacts: false
       artifact_prefix: siteSettings
       testrail_project: Site Settings
       timeout_job: 45

--- a/.github/workflows/nightly-jahiaRelease.yml
+++ b/.github/workflows/nightly-jahiaRelease.yml
@@ -8,16 +8,64 @@ on:
 jobs:
   integration-tests-standalone:
     name: Integration Tests (Standalone)
-    secrets: inherit
-    uses: Jahia/jahia-modules-action/.github/workflows/reusable-integration-tests.yml@v2
-    with:
-      module_id: siteSettings
-      provisioning_manifest: provisioning-manifest-build.yml
-      incident_service: siteSettings-JahiaRL
-      jahia_image: jahia/jahia-ee:8
-      should_skip_artifacts: true
-      should_use_build_artifacts: false
-      artifact_prefix: siteSettings
-      testrail_project: Site Settings
-      timeout_job: 45
-      timeout_step: 20
+    runs-on: self-hosted
+    timeout-minutes: 45
+    steps:
+      - uses: jahia/jahia-modules-action/helper@v2
+      - uses: KengoTODA/actions-setup-docker-compose@main
+        with:
+          version: "1.29.2"
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "lts/*"
+      - uses: actions/checkout@v4
+      - uses: jahia/jahia-modules-action/integration-tests@v2
+        with:
+          module_id: siteSettings
+          incident_service: siteSettings-JahiaRL
+          timeout_minutes: 20
+          testrail_project: Site Settings
+          tests_manifest: provisioning-manifest-snapshot.yml
+          jahia_image: jahia/jahia-ee:8
+          should_use_build_artifacts: false
+          should_skip_artifacts: true
+          should_skip_notifications: false
+          should_skip_testrail: false
+          should_skip_zencrepes: false
+          github_token: ${{ secrets.GH_ISSUES_PRS_CHORES }}
+          github_artifact_name: siteSettings-${{ github.run_number }}
+          jahia_artifact_name: siteSettings-${{ github.run_number }}
+          bastion_ssh_private_key: ${{ secrets.BASTION_SSH_PRIVATE_KEY_JAHIACI }}
+          jahia_license: ${{ secrets.JAHIA_LICENSE_8X_FULL }}
+          docker_registries: |
+            [
+              {
+                "registry": "ghcr.io",
+                "username": "${{ secrets.GH_PACKAGES_USERNAME }}",
+                "password": "${{ secrets.GH_PACKAGES_TOKEN }}"
+              },
+              {
+                "username": "${{ secrets.DOCKERHUB_USERNAME }}",
+                "password": "${{ secrets.DOCKERHUB_PASSWORD }}"
+              }
+            ]
+          nexus_username: ${{ secrets.NEXUS_USERNAME }}
+          nexus_password: ${{ secrets.NEXUS_PASSWORD }}
+          testrail_username: ${{ secrets.TESTRAIL_USERNAME }}
+          testrail_password: ${{ secrets.TESTRAIL_PASSWORD }}
+          tests_report_name: Test report (Standalone)
+          incident_pagerduty_api_key: ${{ secrets.INCIDENT_PAGERDUTY_API_KEY }}
+          incident_pagerduty_reporter_email: ${{ secrets.INCIDENT_PAGERDUTY_REPORTER_EMAIL }}
+          incident_pagerduty_reporter_id: ${{ secrets.INCIDENT_PAGERDUTY_REPORTER_ID }}
+          incident_google_spreadsheet_id: ${{ secrets.INCIDENT_GOOGLE_SPREADSHEET_ID }}
+          incident_google_client_email: ${{ secrets.INCIDENT_GOOGLE_CLIENT_EMAIL }}
+          incident_google_api_key_base64: ${{ secrets.INCIDENT_GOOGLE_PRIVATE_KEY_BASE64 }}
+          zencrepes_secret: ${{ secrets.ZENCREPES_WEBHOOK_SECRET }}
+      - name: Test Report
+        uses: dorny/test-reporter@v1
+        if: success() || failure()
+        with:
+          name: Tests Report (Standalone)
+          path: tests/artifacts/results/xml_reports/**/*.xml
+          reporter: java-junit
+          fail-on-error: "false"

--- a/.github/workflows/nightly-jahiaSnapshot.yml
+++ b/.github/workflows/nightly-jahiaSnapshot.yml
@@ -14,6 +14,8 @@ jobs:
       module_id: siteSettings
       provisioning_manifest: provisioning-manifest-build.yml
       incident_service: siteSettings-JahiaSN
+      should_use_build_artifacts: false
+      should_skip_artifacts: true
       jahia_image: ghcr.io/jahia/jahia-ee-dev:8-SNAPSHOT
       artifact_prefix: siteSettings
       testrail_project: Site Settings

--- a/.github/workflows/nightly-jahiaSnapshot.yml
+++ b/.github/workflows/nightly-jahiaSnapshot.yml
@@ -8,16 +8,64 @@ on:
 jobs:
   integration-tests-standalone:
     name: Integration Tests (Standalone)
-    secrets: inherit
-    uses: Jahia/jahia-modules-action/.github/workflows/reusable-integration-tests.yml@v2
-    with:
-      module_id: siteSettings
-      provisioning_manifest: provisioning-manifest-build.yml
-      incident_service: siteSettings-JahiaSN
-      should_use_build_artifacts: false
-      should_skip_artifacts: true
-      jahia_image: ghcr.io/jahia/jahia-ee-dev:8-SNAPSHOT
-      artifact_prefix: siteSettings
-      testrail_project: Site Settings
-      timeout_job: 45
-      timeout_step: 20
+    runs-on: self-hosted
+    timeout-minutes: 45
+    steps:
+      - uses: jahia/jahia-modules-action/helper@v2
+      - uses: KengoTODA/actions-setup-docker-compose@main
+        with:
+          version: "1.29.2"
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "lts/*"
+      - uses: actions/checkout@v4
+      - uses: jahia/jahia-modules-action/integration-tests@v2
+        with:
+          module_id: siteSettings
+          incident_service: siteSettings-JahiaSN
+          timeout_minutes: 20
+          testrail_project: Site Settings
+          tests_manifest: provisioning-manifest-snapshot.yml
+          jahia_image: ghcr.io/jahia/jahia-ee-dev:8-SNAPSHOT
+          should_use_build_artifacts: false
+          should_skip_artifacts: true
+          should_skip_notifications: false
+          should_skip_testrail: false
+          should_skip_zencrepes: false
+          github_token: ${{ secrets.GH_ISSUES_PRS_CHORES }}
+          github_artifact_name: siteSettings-${{ github.run_number }}
+          jahia_artifact_name: siteSettings-${{ github.run_number }}
+          bastion_ssh_private_key: ${{ secrets.BASTION_SSH_PRIVATE_KEY_JAHIACI }}
+          jahia_license: ${{ secrets.JAHIA_LICENSE_8X_FULL }}
+          docker_registries: |
+            [
+              {
+                "registry": "ghcr.io",
+                "username": "${{ secrets.GH_PACKAGES_USERNAME }}",
+                "password": "${{ secrets.GH_PACKAGES_TOKEN }}"
+              },
+              {
+                "username": "${{ secrets.DOCKERHUB_USERNAME }}",
+                "password": "${{ secrets.DOCKERHUB_PASSWORD }}"
+              }
+            ]
+          nexus_username: ${{ secrets.NEXUS_USERNAME }}
+          nexus_password: ${{ secrets.NEXUS_PASSWORD }}
+          testrail_username: ${{ secrets.TESTRAIL_USERNAME }}
+          testrail_password: ${{ secrets.TESTRAIL_PASSWORD }}
+          tests_report_name: Test report (Standalone)
+          incident_pagerduty_api_key: ${{ secrets.INCIDENT_PAGERDUTY_API_KEY }}
+          incident_pagerduty_reporter_email: ${{ secrets.INCIDENT_PAGERDUTY_REPORTER_EMAIL }}
+          incident_pagerduty_reporter_id: ${{ secrets.INCIDENT_PAGERDUTY_REPORTER_ID }}
+          incident_google_spreadsheet_id: ${{ secrets.INCIDENT_GOOGLE_SPREADSHEET_ID }}
+          incident_google_client_email: ${{ secrets.INCIDENT_GOOGLE_CLIENT_EMAIL }}
+          incident_google_api_key_base64: ${{ secrets.INCIDENT_GOOGLE_PRIVATE_KEY_BASE64 }}
+          zencrepes_secret: ${{ secrets.ZENCREPES_WEBHOOK_SECRET }}
+      - name: Test Report
+        uses: dorny/test-reporter@v1
+        if: success() || failure()
+        with:
+          name: Tests Report (Standalone)
+          path: tests/artifacts/results/xml_reports/**/*.xml
+          reporter: java-junit
+          fail-on-error: "false"


### PR DESCRIPTION
### Description

This pull request updates the nightly workflow configuration for Jahia Release and Snapshot jobs. The main focus is to control the usage and creation of build artifacts during these jobs.

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
