### PR TITLE
test: rename Docker image used by the Cypress tests

### DIFF
--- a/tests/.env.example
+++ b/tests/.env.example
@@ -1,6 +1,6 @@
 JAHIA_VERSION=${JAHIA_VERSION:-LATEST}
 JAHIA_IMAGE=${JAHIA_IMAGE:-ghcr.io/jahia/jahia-ee-dev:8-SNAPSHOT}
-TESTS_IMAGE=${TESTS_IMAGE:-jahia/siteSettings:latest}
+TESTS_IMAGE=${TESTS_IMAGE:-jahia/site-settings:latest}
 MODULE_ID=${MODULE_ID:-siteSettings}
 MANIFEST=${MANIFEST:-provisioning-manifest-build.yml}
 JAHIA_URL=${JAHIA_URL:-http://jahia:8080}


### PR DESCRIPTION
### Description
Currently, it's not possible to run the tests locally with the script by using the `.env.example` file:
```
 ci.build.sh == Build test image
[+] Building 0.0s (0/0)                                                                                                                                                                                                                                                                       docker:desktop-linux
ERROR: failed to build: invalid tag "jahia/siteSettings:latest": repository name must be lowercase
```

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
