### PR TITLE
test: fix tests on new languages screen

### DIFF
--- a/.github/workflows/on-code-change.yml
+++ b/.github/workflows/on-code-change.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: jahia/jahia-modules-action/update-signature@v2 
+      - uses: jahia/jahia-modules-action/update-signature@v2
         with:
           nexus_username: ${{ secrets.NEXUS_USERNAME }}
           nexus_password: ${{ secrets.NEXUS_PASSWORD }}
@@ -64,7 +64,6 @@ jobs:
     uses: Jahia/jahia-modules-action/.github/workflows/reusable-integration-tests.yml@v2
     with:
       module_id: siteSettings
-      module_branch: ${{ github.ref }}
       provisioning_manifest: provisioning-manifest-build.yml
       jahia_image: ghcr.io/jahia/jahia-ee-dev:8-SNAPSHOT
       should_use_build_artifacts: true
@@ -72,4 +71,4 @@ jobs:
       artifact_prefix: siteSettings
       testrail_project: Site Settings
       timeout_job: 45
-      module_branch: ${{ github.head_ref }}
+      module_branch: ${{ github.ref }}

--- a/tests/cypress/e2e/properties.cy.ts
+++ b/tests/cypress/e2e/properties.cy.ts
@@ -40,7 +40,7 @@ describe('Tests for site properties panel', () => {
     it('Navigates to edit languages', () => {
         const siteProps = SiteProperties.visit(siteKey)
         siteProps.editLanguages()
-        cy.get('[aria-labelledby="language-settings"]').should('be.visible')
+        cy.get('h1').contains('Manage languages').should('be.visible')
     })
 
     it('Verifies systemname of system site is readonly', () => {

--- a/tests/cypress/e2e/removingLanguage.test.cy.ts
+++ b/tests/cypress/e2e/removingLanguage.test.cy.ts
@@ -30,17 +30,17 @@ describe('Language deactivation test', () => {
         const siteSettingsLanguages = SiteSettingsLanguages.visit(siteKey)
 
         // Remove active (live & edit) for the non-mandatory French language
-        if (siteSettingsLanguages.isLanguageActivateForTargetMode('fr', 'live', 'active').should('eq', true)) {
-            siteSettingsLanguages.deActivateLanguageForTargetMode('fr', 'live')
-        }
-        if (siteSettingsLanguages.isLanguageActivateForTargetMode('fr', 'edit', 'inactiveInLive').should('eq', true)) {
-            siteSettingsLanguages.deActivateLanguageForTargetMode('fr', 'edit')
-        }
+        siteSettingsLanguages.openLanguageEdit('fr')
+        siteSettingsLanguages.checkLanguageAvailability('Active')
+        siteSettingsLanguages.deActivateLanguageForTargetMode('fr', 'live')
+
+        siteSettingsLanguages.openLanguageEdit('fr')
+        siteSettingsLanguages.checkLanguageAvailability('Inactive in live')
+        siteSettingsLanguages.deActivateLanguageForTargetMode('fr', 'edit')
 
         // Verify that the French language has been deactivated
-        siteSettingsLanguages.isLanguageActivateForTargetMode('fr', 'live', 'active').should('eq', false)
-        siteSettingsLanguages.close()
-        siteSettingsLanguages.isLanguageActivateForTargetMode('fr', 'edit', 'active').should('eq', false)
+        siteSettingsLanguages.openLanguageEdit('fr')
+        siteSettingsLanguages.checkLanguageAvailability('Inactive')
         siteSettingsLanguages.close()
 
         // Verify that we cannot access to the homepage in French in EDIT workspace

--- a/tests/cypress/e2e/siteSettingsLanguagesUI.cy.ts
+++ b/tests/cypress/e2e/siteSettingsLanguagesUI.cy.ts
@@ -170,14 +170,8 @@ describe('UI Site settings language', () => {
 
         const dropDown = getComponentByRole(Dropdown, 'languages')
         dropDown.get().click()
-        getComponent(Menu, dropDown)
-            .get()
-            .find('.moonstone-menuItem')
-            .contains('Afrikaans')
-        getComponent(Menu, dropDown)
-            .get()
-            .find('.moonstone-menuItem')
-            .should('not.contain', 'AA')
+        getComponent(Menu, dropDown).get().find('.moonstone-menuItem').contains('Afrikaans')
+        getComponent(Menu, dropDown).get().find('.moonstone-menuItem').should('not.contain', 'AA')
     })
 
     it('set a language as default', () => {

--- a/tests/cypress/page-object/siteSettingsLanguages.ts
+++ b/tests/cypress/page-object/siteSettingsLanguages.ts
@@ -18,8 +18,8 @@ export class SiteSettingsLanguages extends BasePage {
         getComponent(Menu).select('Edit')
     }
 
-    checkLanguageAvailability(expectedLabel: string) {
-        getComponentByRole(Dropdown, 'availability').get().should('contain.text', expectedLabel)
+    checkLanguageAvailability(expectedValue: string) {
+        getComponentByRole(Dropdown, 'availability').get().should('have.attr', 'data-value', expectedValue)
     }
 
     deActivateLanguageForTargetMode(lang: string, mode: string) {

--- a/tests/cypress/page-object/siteSettingsLanguages.ts
+++ b/tests/cypress/page-object/siteSettingsLanguages.ts
@@ -19,7 +19,10 @@ export class SiteSettingsLanguages extends BasePage {
     }
 
     checkLanguageAvailability(expectedValue: string) {
-        getComponentByRole(Dropdown, 'availability').get().find('[role="listbox"]').should('have.attr', 'aria-label', expectedValue)
+        getComponentByRole(Dropdown, 'availability')
+            .get()
+            .find('[role="listbox"]')
+            .should('have.attr', 'aria-label', expectedValue)
     }
 
     deActivateLanguageForTargetMode(lang: string, mode: string) {

--- a/tests/cypress/page-object/siteSettingsLanguages.ts
+++ b/tests/cypress/page-object/siteSettingsLanguages.ts
@@ -6,7 +6,7 @@ export class SiteSettingsLanguages extends BasePage {
         return new SiteSettingsLanguages()
     }
 
-    isLanguageActivateForTargetMode(lang: string, mode: string, expectedValue: string) {
+    openLanguageEdit(lang: string) {
         getComponent(Table)
             .get()
             .find(`span.moonstone-pill:contains('${lang}')`)
@@ -16,11 +16,12 @@ export class SiteSettingsLanguages extends BasePage {
             .last()
             .click()
         getComponent(Menu).select('Edit')
-        return getComponentByRole(Dropdown, 'availability')
+    }
+
+    checkLanguageAvailability(expectedLabel: string) {
+        getComponentByRole(Dropdown, 'availability')
             .get()
-            .then(($el) => {
-                return $el.attr('data-value') === expectedValue
-            })
+            .should('contain.text', expectedLabel)
     }
 
     deActivateLanguageForTargetMode(lang: string, mode: string) {

--- a/tests/cypress/page-object/siteSettingsLanguages.ts
+++ b/tests/cypress/page-object/siteSettingsLanguages.ts
@@ -19,7 +19,7 @@ export class SiteSettingsLanguages extends BasePage {
     }
 
     checkLanguageAvailability(expectedValue: string) {
-        getComponentByRole(Dropdown, 'availability').get().should('have.attr', 'data-value', expectedValue)
+        getComponentByRole(Dropdown, 'availability').get().find('[role="listbox"]').should('have.attr', 'aria-label', expectedValue)
     }
 
     deActivateLanguageForTargetMode(lang: string, mode: string) {

--- a/tests/cypress/page-object/siteSettingsLanguages.ts
+++ b/tests/cypress/page-object/siteSettingsLanguages.ts
@@ -19,9 +19,7 @@ export class SiteSettingsLanguages extends BasePage {
     }
 
     checkLanguageAvailability(expectedLabel: string) {
-        getComponentByRole(Dropdown, 'availability')
-            .get()
-            .should('contain.text', expectedLabel)
+        getComponentByRole(Dropdown, 'availability').get().should('contain.text', expectedLabel)
     }
 
     deActivateLanguageForTargetMode(lang: string, mode: string) {


### PR DESCRIPTION
### Description
siteSettings-8.12.0-SNAPSHOT build is skipped because the tests are failing : https://github.com/Jahia/siteSettings/actions/runs/27360968206/job/80994183346
- refactored `Should be able to deactivate a non-mandatory language`
- check for h1 in `Navigates to edit languages`
- fixed workflow

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
