### PR TITLE
ci: fix network config to ensure containers does not need docker DNS

### DIFF
--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -32,9 +32,8 @@ services:
             - mariadb
         extra_hosts:
           - "jahia:172.18.0.10"
-          - "jahia-p:172.18.0.10"
-          - "jahia-b1:172.18.0.11"
-          - "jahia-b2:172.18.0.12"
+          - "jahia-browsing-a:172.18.0.11"
+          - "jahia-browsing-b:172.18.0.12"
         networks:
           default:
             ipv4_address: 172.18.0.10
@@ -75,9 +74,8 @@ services:
             - jahia
         extra_hosts:
           - "jahia:172.18.0.10"
-          - "jahia-p:172.18.0.10"
-          - "jahia-b1:172.18.0.11"
-          - "jahia-b2:172.18.0.12"
+          - "jahia-browsing-a:172.18.0.11"
+          - "jahia-browsing-b:172.18.0.12"
         networks:
           default:
             ipv4_address: 172.18.0.11
@@ -117,9 +115,8 @@ services:
             - jahia
         extra_hosts:
           - "jahia:172.18.0.10"
-          - "jahia-p:172.18.0.10"
-          - "jahia-b1:172.18.0.11"
-          - "jahia-b2:172.18.0.12"
+          - "jahia-browsing-a:172.18.0.11"
+          - "jahia-browsing-b:172.18.0.12"
         networks:
           default:
             ipv4_address: 172.18.0.12
@@ -175,6 +172,8 @@ services:
           ipv4_address: 172.18.0.20
       extra_hosts:
         - "jahia:172.18.0.10"
+        - "jahia-browsing-a:172.18.0.11"
+        - "jahia-browsing-b:172.18.0.12"
 networks:
   default:
     ipam:

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -7,8 +7,11 @@ services:
             resources:
                 limits:
                     memory: 1gb
+        extra_hosts:
+          - "mariadb:172.18.0.5"
         networks:
-            - stack
+          default:
+            ipv4_address: 172.18.0.5
         command: --max_allowed_packet=1073741824 --transaction-isolation=READ-UNCOMMITTED --innodb-lock-wait-timeout=10
         environment:
             MYSQL_ROOT_PASSWORD: root1234
@@ -27,14 +30,18 @@ services:
                     memory: 4gb
         depends_on:
             - mariadb
+        extra_hosts:
+          - "jahia:172.18.0.10"
+          - "jahia-p:172.18.0.10"
+          - "jahia-b1:172.18.0.11"
+          - "jahia-b2:172.18.0.12"
         networks:
-            - stack
+          default:
+            ipv4_address: 172.18.0.10
         ports:
             - "8080:8080"
             - "8101:8101"
             - "8000:8000"
-        extra_hosts:
-            - jahia:127.0.0.1
         environment:
             jahia_cfg_karaf_remoteShellHost: 0.0.0.0
             DB_VENDOR: mariadb
@@ -66,8 +73,14 @@ services:
         depends_on:
             - mariadb
             - jahia
+        extra_hosts:
+          - "jahia:172.18.0.10"
+          - "jahia-p:172.18.0.10"
+          - "jahia-b1:172.18.0.11"
+          - "jahia-b2:172.18.0.12"
         networks:
-            - stack
+          default:
+            ipv4_address: 172.18.0.11
         ports:
             - '8081:8080'
             - '8102:8101'
@@ -102,8 +115,14 @@ services:
         depends_on:
             - mariadb
             - jahia
+        extra_hosts:
+          - "jahia:172.18.0.10"
+          - "jahia-p:172.18.0.10"
+          - "jahia-b1:172.18.0.11"
+          - "jahia-b2:172.18.0.12"
         networks:
-            - stack
+          default:
+            ipv4_address: 172.18.0.12
         ports:
             - '8082:8080'
             - '8103:8101'
@@ -152,6 +171,12 @@ services:
         JAHIA_CLUSTER_ENABLED: '${JAHIA_CLUSTER_ENABLED}'
         TZ: ${TIMEZONE}
       networks:
-        - stack
+        default:
+          ipv4_address: 172.18.0.20
+      extra_hosts:
+        - "jahia:172.18.0.10"
 networks:
-    stack:
+  default:
+    ipam:
+      config:
+        - subnet: 172.18.0.0/16


### PR DESCRIPTION
### Description

This pull request updates the `tests/docker-compose.yml` file to assign static IP addresses to service containers and to add explicit `extra_hosts` entries, improving network predictability and inter-service communication in the test environment. The custom network configuration replaces the previous `stack` network with a `default` network that specifies a subnet and static IPs for each service.

Key changes:

**Network configuration and static IP assignment:**

* Replaces the `stack` network with a custom `default` network, specifying a subnet (`172.18.0.0/16`) and assigning static IPv4 addresses to all major services (`mariadb`, `jahia`, `jahia-b1`, `jahia-b2`, and others). [[1]](diffhunk://#diff-e63f0ca35966a726ffc6894c07d1fe38b1870304c71f615e9cd404789c357732R10-R14) [[2]](diffhunk://#diff-e63f0ca35966a726ffc6894c07d1fe38b1870304c71f615e9cd404789c357732R33-L37) [[3]](diffhunk://#diff-e63f0ca35966a726ffc6894c07d1fe38b1870304c71f615e9cd404789c357732R76-R83) [[4]](diffhunk://#diff-e63f0ca35966a726ffc6894c07d1fe38b1870304c71f615e9cd404789c357732R118-R125) [[5]](diffhunk://#diff-e63f0ca35966a726ffc6894c07d1fe38b1870304c71f615e9cd404789c357732L155-R182)

**Explicit host mapping for service discovery:**

* Adds `extra_hosts` configuration to each service, mapping service hostnames (e.g., `jahia`, `jahia-b1`, `jahia-b2`) to their assigned static IPs, ensuring reliable hostname resolution between containers. [[1]](diffhunk://#diff-e63f0ca35966a726ffc6894c07d1fe38b1870304c71f615e9cd404789c357732R10-R14) [[2]](diffhunk://#diff-e63f0ca35966a726ffc6894c07d1fe38b1870304c71f615e9cd404789c357732R33-L37) [[3]](diffhunk://#diff-e63f0ca35966a726ffc6894c07d1fe38b1870304c71f615e9cd404789c357732R76-R83) [[4]](diffhunk://#diff-e63f0ca35966a726ffc6894c07d1fe38b1870304c71f615e9cd404789c357732R118-R125) [[5]](diffhunk://#diff-e63f0ca35966a726ffc6894c07d1fe38b1870304c71f615e9cd404789c357732L155-R182)