### PR TITLE
chore: add fr and de translations on new languages screen

### DIFF
--- a/src/main/resources/javascript/locales/de.json
+++ b/src/main/resources/javascript/locales/de.json
@@ -37,5 +37,81 @@
     "mandatoryLanguages": "Verpflichtende Sprachen",
     "defaultLanguage": "Standardsprache",
     "creationDate": "Erstellungsdatum"
+  },
+  "label": {
+    "title": "Sprachen",
+    "header": "Sprachen für \"{{ siteName }}\"",
+    "actions": {
+      "add": "Hinzufügen",
+      "cancel": "Abbrechen",
+      "close": "Schließen",
+      "edit": "Bearbeiten",
+      "more": "Mehr für {{ language }}",
+      "save": "Speichern"
+    },
+    "untranslatedContent": {
+      "title": "Standardsprache anzeigen, wenn der Inhalt nicht übersetzt ist",
+      "never": "Nie (empfohlen für Webseiten)",
+      "only": "Nur für von der Webseite unterstützte Sprachen",
+      "all": "Alle Sprachen, auch die von der Webseite nicht unterstützten",
+      "modal": "Ersatzsprache festlegen"
+    },
+    "modal": {
+      "header": "Sprache {{ action }}",
+      "language": {
+        "title": "Sprache",
+        "placeholder": "Sprache auswählen"
+      },
+      "default": "Standardsprache",
+      "availability": {
+        "title": "Verfügbarkeit",
+        "placeholder": "Aktiv, In Live ausgeblendet, Erforderlich, Inaktiv"
+      },
+      "error": {
+        "title": "Fehler",
+        "description": "Ein Fehler ist aufgetreten"
+      }
+    },
+    "availability": {
+      "inactive": {
+        "title": "Inaktiv",
+        "description": "Inhalt ist nicht bearbeitbar und in Live nicht sichtbar"
+      },
+      "inactiveInLive": {
+        "title": "In Live inaktiv",
+        "description": "Inhalt ist bearbeitbar, aber in Live nicht sichtbar"
+      },
+      "active": {
+        "title": "Aktiv",
+        "description": "Inhalt ist bearbeitbar und in Live sichtbar"
+      },
+      "required": {
+        "title": "Erforderlich",
+        "description": "Pflichtsprache zur Veröffentlichung aller anderen Sprachen (bearbeitbar und in Live sichtbar)"
+      }
+    },
+    "table": {
+      "th": {
+        "default": "Standard",
+        "languages": "Sprachen",
+        "availability": "Verfügbarkeit"
+      },
+      "actions": {
+        "add": "Sprache hinzufügen",
+        "default": {
+          "title": "Als Standardsprache festlegen",
+          "error": "Diese Sprache ist bereits die Standardsprache."
+        },
+        "delete": {
+          "title": "Löschen",
+          "error": {
+            "activeInEdit": "Diese Sprache ist im Bearbeitungsmodus aktiv und kann nicht gelöscht werden.",
+            "default": "Diese Sprache ist die Standardsprache und kann nicht gelöscht werden.",
+            "language": "Diese Sprache wird von {{ count }} Inhalt(en) verwendet und kann nicht gelöscht werden.",
+            "mandatory": "Diese Sprache ist eine Pflichtsprache und kann nicht gelöscht werden."
+          }
+        }
+      }
+    }
   }
 }

--- a/src/main/resources/javascript/locales/fr.json
+++ b/src/main/resources/javascript/locales/fr.json
@@ -37,5 +37,81 @@
     "mandatoryLanguages": "Langues obligatoires",
     "defaultLanguage": "Langue par défaut",
     "creationDate": "Date de création"
+  },
+  "label": {
+    "title": "Langues",
+    "header": "Gérer les langues pour \"{{ siteName }}\"",
+    "actions": {
+      "add": "Ajouter",
+      "cancel": "Annuler",
+      "close": "Fermer",
+      "edit": "Modifier",
+      "more": "Plus {{ language }}",
+      "save": "Enregistrer"
+    },
+    "untranslatedContent": {
+      "title": "Afficher la langue par défaut lorsque le contenu n'est pas traduit",
+      "never": "Jamais (recommandé pour un site web)",
+      "only": "Uniquement pour les langues prises en charge par le site web",
+      "all": "Toutes les langues, même celles non prises en charge par le site web",
+      "modal": "Définir la langue par défaut"
+    },
+    "modal": {
+      "header": "{{ action }} une langue",
+      "language": {
+        "title": "Langue",
+        "placeholder": "Sélectionner une langue"
+      },
+      "default": "Langue par défaut",
+      "availability": {
+        "title": "Disponibilité",
+        "placeholder": "Active, Masquée en live, Obligatoire, Inactive"
+      },
+      "error": {
+        "title": "Erreur",
+        "description": "Une erreur est survenue"
+      }
+    },
+    "availability": {
+      "inactive": {
+        "title": "Inactive",
+        "description": "Le contenu n'est pas modifiable et n'est pas visible en live"
+      },
+      "inactiveInLive": {
+        "title": "Inactive en live",
+        "description": "Le contenu est modifiable mais n'est pas visible en live"
+      },
+      "active": {
+        "title": "Active",
+        "description": "Le contenu est modifiable et visible en live"
+      },
+      "required": {
+        "title": "Obligatoire",
+        "description": "Langue obligatoire pour publier toute autre langue (modifiable et visible en live)"
+      }
+    },
+    "table": {
+      "th": {
+        "default": "Par défaut",
+        "languages": "Langues",
+        "availability": "Disponibilité"
+      },
+      "actions": {
+        "add": "Ajouter une langue",
+        "default": {
+          "title": "Définir comme langue par défaut",
+          "error": "Cette langue est déjà la langue par défaut."
+        },
+        "delete": {
+          "title": "Supprimer",
+          "error": {
+            "activeInEdit": "Cette langue est active en mode édition et ne peut pas être supprimée.",
+            "default": "Cette langue est la langue par défaut et ne peut pas être supprimée.",
+            "language": "Cette langue est utilisée par {{ count }} contenu(s) et ne peut pas être supprimée.",
+            "mandatory": "Cette langue est obligatoire et ne peut pas être supprimée."
+          }
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
### Description
Add translations in French and German on the new languages screen.

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
