### PR TITLE
fix: consistently escape special characters in page model names (Page Models admin)

### DIFF
--- a/.chachalog/b3Xq9wRt.md
+++ b/.chachalog/b3Xq9wRt.md
@@ -1,0 +1,6 @@
+---
+# Allowed version bumps: patch, minor, major
+siteSettings: patch
+---
+
+Fixed display of page model names and titles containing special characters in the Page Models administration screen.

--- a/src/main/resources/jnt_siteSettingsManagePageModels/html/siteSettingsManagePageModels.jsp
+++ b/src/main/resources/jnt_siteSettingsManagePageModels/html/siteSettingsManagePageModels.jsp
@@ -54,13 +54,13 @@
                      scriptInfo="" path="${pageModel.path}" template="hidden.system" dragdrop="false">
                     <table class="table table-bordered">
                         <tr>
-                            <td>${pageModel.displayableName}</td>
+                            <td>${fn:escapeXml(pageModel.displayableName)}</td>
                         </tr>
                     </table>
                 </div>
             </td>
             <td>
-                <a href="<c:url value='${url.base}${pageModel.path}.html'/>">${pageModel.properties["j:pageTemplateTitle"].string}</a>
+                <a href="<c:url value='${url.base}${pageModel.path}.html'/>"><c:out value='${pageModel.properties["j:pageTemplateTitle"].string}'/></a>
             </td>
             <td>  <a href="<c:url value='${url.base}${pageModel.path}.html'/>">${pageModel.path}</a></td>
 

--- a/src/main/resources/jnt_siteSettingsManagePageModels/html/siteSettingsManagePageModels.settingsBootstrap3GoogleMaterialStyle.jsp
+++ b/src/main/resources/jnt_siteSettingsManagePageModels/html/siteSettingsManagePageModels.settingsBootstrap3GoogleMaterialStyle.jsp
@@ -55,13 +55,13 @@
                              scriptInfo="" path="${pageModel.path}" template="hidden.system" dragdrop="false">
                             <table class="table table-bordered">
                                 <tr>
-                                    <td>${pageModel.displayableName}</td>
+                                    <td>${fn:escapeXml(pageModel.displayableName)}</td>
                                 </tr>
                             </table>
                         </div>
                     </td>
                     <td>
-                        <a href="<c:url value='${url.base}${pageModel.path}.html'/>">${pageModel.properties["j:pageTemplateTitle"].string}</a>
+                        <a href="<c:url value='${url.base}${pageModel.path}.html'/>"><c:out value='${pageModel.properties["j:pageTemplateTitle"].string}'/></a>
                     </td>
                     <td>
                         <a href="<c:url value='${url.base}${pageModel.path}.html'/>">${pageModel.path}</a>


### PR DESCRIPTION
### Summary
Page model **names and titles** containing special characters (`<`, `>`, `&`, quotes) were not consistently escaped when rendered in the **Page Models** administration screen, so such values could be displayed incorrectly.

### Change
HTML-escape `pageModel.displayableName` and `j:pageTemplateTitle` (`fn:escapeXml` / `c:out`) in the Page Models admin JSP (default + Bootstrap3/Material variants), mirroring the file's existing convention for the sibling site name. Fixed at the JSP layer: the shared core getter is intentionally raw and already escaped by its callers, so changing the getter would double-escape other call sites.

### Verification
Deploy-tested on a local 8.2.x instance: page model names and titles containing special characters now render correctly.
