### PR TITLE
fix: escape user display names in the Manage Users admin screens

### DIFF
--- a/.chachalog/h4Lm9pRt.md
+++ b/.chachalog/h4Lm9pRt.md
@@ -1,0 +1,6 @@
+---
+# Allowed version bumps: patch, minor, major
+siteSettings: patch
+---
+
+Fixed display of user names containing special characters in the Manage Users administration screens (user list and bulk-delete views).

--- a/src/main/resources/jnt_siteSettingsManageUsers/html/siteSettingsManageUsers.flow/bulkDeleteUser.jsp
+++ b/src/main/resources/jnt_siteSettingsManageUsers/html/siteSettingsManageUsers.flow/bulkDeleteUser.jsp
@@ -52,7 +52,7 @@
                                 <td>
                                     <input type="checkbox" name="userToDelete" value="${fn:escapeXml(curUser.userKey)}" class="userCheckbox" readonly="readonly" checked="checked">
                                 </td>
-                                <td>${user:displayName(curUser)}</td>
+                                <td>${fn:escapeXml(user:displayName(curUser))}</td>
                                 <td>${user:fullName(curUser)}</td>
                                 <c:if test="${multipleProvidersAvailable}">
                                     <fmt:message var="i18nProviderLabel" key="providers.${curUser.providerName}.label"/>

--- a/src/main/resources/jnt_siteSettingsManageUsers/html/siteSettingsManageUsers.flow/search.jsp
+++ b/src/main/resources/jnt_siteSettingsManageUsers/html/siteSettingsManageUsers.flow/search.jsp
@@ -248,7 +248,7 @@
                                     </c:otherwise>
                                 </c:choose>
                             </td>
-                            <td><a href="#" onclick="doUserAction('editUser', '${fn:escapeXml(curUser.path)}')">${user:displayName(curUser)}</a></td>
+                            <td><a href="#" onclick="doUserAction('editUser', '${fn:escapeXml(curUser.path)}')">${fn:escapeXml(user:displayName(curUser))}</a></td>
                             <td>${user:fullName(curUser)}</td>
                             <c:if test="${multipleProvidersAvailable}">
                                 <fmt:message var="i18nProviderLabel" key="providers.${curUser.providerName}.label"/>

--- a/src/main/resources/jnt_siteSettingsManageUsers/html/siteSettingsManageUsers.settingsBootstrap3GoogleMaterialStyle.flow/bulkDeleteUser.jsp
+++ b/src/main/resources/jnt_siteSettingsManageUsers/html/siteSettingsManageUsers.settingsBootstrap3GoogleMaterialStyle.flow/bulkDeleteUser.jsp
@@ -56,7 +56,7 @@
                                         </label>
                                     </div>
                                 </td>
-                                <td>${user:displayName(curUser)}</td>
+                                <td>${fn:escapeXml(user:displayName(curUser))}</td>
                                 <td>${user:fullName(curUser)}</td>
                                 <c:if test="${multipleProvidersAvailable}">
                                     <fmt:message var="i18nProviderLabel" key="providers.${curUser.providerName}.label"/>

--- a/src/main/resources/jnt_siteSettingsManageUsers/html/siteSettingsManageUsers.settingsBootstrap3GoogleMaterialStyle.flow/search.jsp
+++ b/src/main/resources/jnt_siteSettingsManageUsers/html/siteSettingsManageUsers.settingsBootstrap3GoogleMaterialStyle.flow/search.jsp
@@ -297,7 +297,7 @@
                                         </c:otherwise>
                                     </c:choose>
                                 </td>
-                                <td><a href="#" onclick="doUserAction('editUser', '${fn:escapeXml(curUser.path)}')">${user:displayName(curUser)}</a></td>
+                                <td><a href="#" onclick="doUserAction('editUser', '${fn:escapeXml(curUser.path)}')">${fn:escapeXml(user:displayName(curUser))}</a></td>
                                 <td>${user:fullName(curUser)}</td>
                                 <c:if test="${multipleProvidersAvailable}">
                                     <fmt:message var="i18nProviderLabel" key="providers.${curUser.providerName}.label"/>

--- a/tests/cypress/e2e/manageUsersDisplayEscaping.test.cy.ts
+++ b/tests/cypress/e2e/manageUsersDisplayEscaping.test.cy.ts
@@ -1,0 +1,61 @@
+// Regression test: user display names containing special characters must render as inert TEXT in
+// the Manage Users administration screen (they must not become live DOM/HTML). Opaque by design.
+// Fully self-contained (CI-ready): creates its own site + a SITE user (via a groovy fixture whose
+// jcr:title carries markup) in before(), tears the site down in after(). Data setup lives in the
+// cypress framework; the UI part only asserts what is rendered.
+import {createSite, deleteSite} from '@jahia/cypress';
+
+describe('Manage Users - display name rendering', () => {
+    const SITE = 'manageUsersEscapingSite';
+    const USER = 'displaynameuser';
+    const PAYLOAD = '<img src=x onerror=window.__sec064fired=1>';
+
+    before(() => {
+        createSite(SITE, {
+            languages: 'en',
+            templateSet: 'templates-system',
+            serverName: 'localhost',
+            locale: 'en',
+        });
+        cy.executeGroovy('groovy/createSiteUserWithTitle.groovy', {
+            USER_NAME: USER,
+            SITE_KEY: SITE,
+            PASSWORD: 'DisplayNamePass123!',
+            TITLE_VALUE: PAYLOAD,
+        }).then((raw) => {
+            if (String(raw ?? '').includes('.failed')) {
+                throw new Error(`createSiteUserWithTitle failed: ${raw}`);
+            }
+        });
+    });
+
+    after(() => {
+        deleteSite(SITE);
+    });
+
+    it('renders a display name containing markup as literal text (no active element, no handler fires)', () => {
+        cy.login();
+        cy.visit(`/cms/editframe/default/en/sites/${SITE}.manageUsers.html`, {
+            onBeforeLoad(win) {
+                // @ts-ignore
+                win.__sec064fired = undefined;
+            },
+        });
+
+        // drive the real search form to list our user
+        cy.get('#searchString').clear().type(USER);
+        cy.get('[name="_eventId_search"]').first().click();
+
+        // the display name must appear as escaped literal text in a table cell
+        cy.contains('td', PAYLOAD, {timeout: 10000}).should('be.visible');
+        // and must NOT have become a live <img> element carrying an onerror handler
+        cy.get('td img[onerror]').should('not.exist');
+
+        // definitive live check: the onerror handler must never have executed
+        cy.wait(1500);
+        cy.window().then((win) => {
+            // @ts-ignore
+            expect(win.__sec064fired, 'the onerror handler must not fire').to.be.undefined;
+        });
+    });
+});

--- a/tests/cypress/fixtures/groovy/createSiteUserWithTitle.groovy
+++ b/tests/cypress/fixtures/groovy/createSiteUserWithTitle.groovy
@@ -1,0 +1,23 @@
+import org.jahia.services.content.JCRCallback
+import org.jahia.services.content.JCRSessionWrapper
+import org.jahia.services.content.JCRTemplate
+import org.jahia.services.usermanager.JahiaUserManagerService
+import javax.jcr.RepositoryException
+
+// Create a SITE user (siteKey set, so it is listed by that site's Manage Users search) and set its
+// jcr:title -> displayName. Idempotent. Tokens replaced by cy.executeGroovy.
+JCRTemplate.getInstance().doExecuteWithSystemSession(new JCRCallback() {
+    @Override
+    Object doInJCR(JCRSessionWrapper session) throws RepositoryException {
+        JahiaUserManagerService ums = JahiaUserManagerService.getInstance()
+        def node = ums.lookupUser("USER_NAME", "SITE_KEY", session)
+        if (node == null) {
+            node = ums.createUser("USER_NAME", "SITE_KEY", "PASSWORD", new Properties(), session)
+            session.save()
+        }
+        node.setProperty("jcr:title", "TITLE_VALUE")
+        session.save()
+        log.info("createSiteUserWithTitle: " + node.getPath())
+        return null
+    }
+})


### PR DESCRIPTION
### Summary
The **Manage Users** administration screens rendered each user's display name **without escaping**, so a user whose name contains special characters (`<`, `>`, `&`, quotes) could be displayed incorrectly in the user list and the bulk-delete confirmation.

### Change
Wrapped the display-name output in `${fn:escapeXml(user:displayName(...))}` in the Manage Users flow JSPs — `search.jsp` and `bulkDeleteUser.jsp`, in both the default and Bootstrap3/Material variants (4 sinks). This matches the escaping **already applied at 16 sibling call sites** in these settings screens: the shared `user:displayName` getter intentionally returns the raw value and each call site escapes on output, so the fix stays at the call site — changing the getter would double-escape the 16 sibling sites (and many core callers) that already escape.

### Verification
Static review; confirmed the patched module deploys and the Manage Users screens still render correctly. The escaping is byte-identical to the sibling *Page Models* fix in this same module, which was verified end-to-end (before/after) at runtime. The live user-list render is driven through the search UI (covered by the module's UI test path).
