### PR TITLE
fix: escape member display name in Manage Groups edit view (material theme)

### DIFF
--- a/.chachalog/JfBDyh1b.md
+++ b/.chachalog/JfBDyh1b.md
@@ -1,0 +1,6 @@
+---
+# Allowed version bumps: patch, minor, major
+sitesettings: minor
+---
+
+Escape the member display name in the Manage Groups edit view (Material theme) so it matches the escaping already applied in the standard theme.

--- a/.chachalog/JfBDyh1b.md
+++ b/.chachalog/JfBDyh1b.md
@@ -1,6 +1,6 @@
 ---
 # Allowed version bumps: patch, minor, major
-sitesettings: minor
+siteSettings: patch
 ---
 
 Escape the member display name in the Manage Groups edit view (Material theme) so it matches the escaping already applied in the standard theme.

--- a/src/main/resources/jnt_siteSettingsManageGroups/html/siteSettingsManageGroups.settingsBootstrap3GoogleMaterialStyle.flow/editGroup.jsp
+++ b/src/main/resources/jnt_siteSettingsManageGroups/html/siteSettingsManageGroups.settingsBootstrap3GoogleMaterialStyle.flow/editGroup.jsp
@@ -220,7 +220,7 @@
                                   <i class="material-icons" style="vertical-align:middle">${principalIcon}</i>
                                 </td>
                                 <td>
-                                    ${user:displayName(member)}
+                                    ${fn:escapeXml(user:displayName(member))}
                                 </td>
                                 <td>
                                     ${user:fullName(member)}


### PR DESCRIPTION
The Manage Groups edit-group members list rendered the member display name unescaped in the Material theme view, whereas the standard theme view already escapes it. This makes the two views consistent.