### PR TITLE
fix: render the Page Models page path column consistently with the other columns

### DIFF
--- a/.chachalog/4aF7pfla.md
+++ b/.chachalog/4aF7pfla.md
@@ -2,4 +2,4 @@
 siteSettings: patch
 ---
 
-Render the Page Models page path column consistently with the page name and model name columns
+Fixed display of page paths containing special characters in the Page Models administration screen.

--- a/.chachalog/4aF7pfla.md
+++ b/.chachalog/4aF7pfla.md
@@ -1,0 +1,5 @@
+---
+siteSettings: patch
+---
+
+Render the Page Models page path column consistently with the page name and model name columns

--- a/src/main/resources/jnt_siteSettingsManagePageModels/html/siteSettingsManagePageModels.jsp
+++ b/src/main/resources/jnt_siteSettingsManagePageModels/html/siteSettingsManagePageModels.jsp
@@ -62,7 +62,7 @@
             <td>
                 <a href="<c:url value='${url.base}${pageModel.path}.html'/>"><c:out value='${pageModel.properties["j:pageTemplateTitle"].string}'/></a>
             </td>
-            <td>  <a href="<c:url value='${url.base}${pageModel.path}.html'/>">${pageModel.path}</a></td>
+            <td>  <a href="<c:url value='${url.base}${pageModel.path}.html'/>"><c:out value='${pageModel.path}'/></a></td>
 
         </tr>
         <c:set var="isEmpty" value="false"/>

--- a/src/main/resources/jnt_siteSettingsManagePageModels/html/siteSettingsManagePageModels.settingsBootstrap3GoogleMaterialStyle.jsp
+++ b/src/main/resources/jnt_siteSettingsManagePageModels/html/siteSettingsManagePageModels.settingsBootstrap3GoogleMaterialStyle.jsp
@@ -64,7 +64,7 @@
                         <a href="<c:url value='${url.base}${pageModel.path}.html'/>"><c:out value='${pageModel.properties["j:pageTemplateTitle"].string}'/></a>
                     </td>
                     <td>
-                        <a href="<c:url value='${url.base}${pageModel.path}.html'/>">${pageModel.path}</a>
+                        <a href="<c:url value='${url.base}${pageModel.path}.html'/>"><c:out value='${pageModel.path}'/></a>
                     </td>
                 </tr>
                 <c:set var="isEmpty" value="false"/>

--- a/tests/cypress/e2e/managePageModelsDisplayEscaping.test.cy.ts
+++ b/tests/cypress/e2e/managePageModelsDisplayEscaping.test.cy.ts
@@ -46,6 +46,9 @@ describe('Manage Page Models - path rendering', () => {
         cy.get('body').then(($b) => {
             const rowText = $b.find('#pageModelsTable tbody').text()
             if (!rowText.includes(SITE_PATH) && attempt < 10) {
+                // deliberate pacing: the row is served from Oak's async index, which has no
+                // deterministic client-side signal to wait on.
+                // eslint-disable-next-line cypress/no-unnecessary-waiting
                 cy.wait(3000)
                 openUntilRowPresent(attempt + 1)
             }

--- a/tests/cypress/e2e/managePageModelsDisplayEscaping.test.cy.ts
+++ b/tests/cypress/e2e/managePageModelsDisplayEscaping.test.cy.ts
@@ -1,0 +1,73 @@
+// Regression test: a page-model's path shown in the Page Models administration screen must render as
+// inert TEXT (it must not become live DOM/HTML), including when the underlying node name contains
+// reserved markup characters. Fully self-contained (CI-ready): creates its own site + a template-model
+// page whose node NAME carries markup in before(), tears the site down in after(). Data setup lives in
+// the cypress framework; the UI part only asserts what is rendered.
+import { createSite, deleteSite } from '@jahia/cypress'
+
+describe('Manage Page Models - path rendering', () => {
+    const SITE = 'pageModelsEscapingSite'
+    const SITE_PATH = `/sites/${SITE}`
+    // The node name flows into the "page path" column. A node name cannot contain '/', so this value is
+    // slash-free; the onerror handler flips a window flag we can assert never ran.
+    const MARKUP = '<img src=x onerror=window.__pageModelsPathHandlerFired=1>'
+
+    before(() => {
+        createSite(SITE, {
+            languages: 'en',
+            templateSet: 'templates-system',
+            serverName: 'localhost',
+            locale: 'en',
+        })
+        cy.executeGroovy('groovy/createPageModelWithMarkupName.groovy', {
+            SITE_KEY: SITE,
+            MARKUP_NAME: MARKUP,
+        }).then((raw) => {
+            if (String(raw ?? '').includes('.failed')) {
+                throw new Error(`createPageModelWithMarkupName failed: ${raw}`)
+            }
+        })
+    })
+
+    after(() => {
+        deleteSite(SITE)
+    })
+
+    // Open the Page Models admin screen and reload until the planted page-model surfaces in the list.
+    // The row is populated by a JCR-SQL2 query served from Oak's async index, which lags a fresh plant
+    // by a few seconds; without this the list can render empty and the assertions would be vacuous.
+    const openUntilRowPresent = (attempt = 0) => {
+        cy.visit(`/cms/editframe/default/en/sites/${SITE}.page-models.html`, {
+            onBeforeLoad(win) {
+                ;(win as unknown as Record<string, unknown>).__pageModelsPathHandlerFired = undefined
+            },
+        })
+        cy.get('#pageModelsTable', { timeout: 10000 })
+        cy.get('body').then(($b) => {
+            const rowText = $b.find('#pageModelsTable tbody').text()
+            if (!rowText.includes(SITE_PATH) && attempt < 10) {
+                cy.wait(3000)
+                openUntilRowPresent(attempt + 1)
+            }
+        })
+    }
+
+    it('renders a page-model path containing markup as literal text (no active element, no handler fires)', () => {
+        cy.login()
+        openUntilRowPresent()
+
+        // the path must appear as escaped literal text inside its link cell
+        cy.contains('a', MARKUP, { timeout: 10000 }).should('be.visible')
+        // and must NOT have become a live <img> element carrying an onerror handler
+        cy.get('td img[onerror]').should('not.exist')
+
+        // definitive live check: the onerror handler must never have executed (by the time the link
+        // above has rendered as visible text, any onerror would already have fired).
+        cy.window().then((win) => {
+            expect(
+                (win as unknown as Record<string, unknown>).__pageModelsPathHandlerFired,
+                'the onerror handler must not fire',
+            ).to.be.undefined
+        })
+    })
+})

--- a/tests/cypress/e2e/managePageModelsDisplayEscaping.test.cy.ts
+++ b/tests/cypress/e2e/managePageModelsDisplayEscaping.test.cy.ts
@@ -36,22 +36,28 @@ describe('Manage Page Models - path rendering', () => {
     // Open the Page Models admin screen and reload until the planted page-model surfaces in the list.
     // The row is populated by a JCR-SQL2 query served from Oak's async index, which lags a fresh plant
     // by a few seconds; without this the list can render empty and the assertions would be vacuous.
-    const openUntilRowPresent = (attempt = 0) => {
+    const MAX_ATTEMPTS = 10
+    const openUntilRowPresent = (attempt = 0): Cypress.Chainable => {
         cy.visit(`/cms/editframe/default/en/sites/${SITE}.page-models.html`, {
             onBeforeLoad(win) {
                 ;(win as unknown as Record<string, unknown>).__pageModelsPathHandlerFired = undefined
             },
         })
-        cy.get('#pageModelsTable', { timeout: 10000 })
-        cy.get('body').then(($b) => {
-            const rowText = $b.find('#pageModelsTable tbody').text()
-            if (!rowText.includes(SITE_PATH) && attempt < 10) {
-                // deliberate pacing: the row is served from Oak's async index, which has no
-                // deterministic client-side signal to wait on.
-                // eslint-disable-next-line cypress/no-unnecessary-waiting
-                cy.wait(3000)
-                openUntilRowPresent(attempt + 1)
+        // return the chain so the caller's assertions are queued strictly after the retries
+        return cy.get('#pageModelsTable tbody', { timeout: 10000 }).then(($tbody) => {
+            if ($tbody.text().includes(SITE_PATH)) {
+                return
             }
+            if (attempt >= MAX_ATTEMPTS) {
+                throw new Error(
+                    `page-model row (${SITE_PATH}) never appeared in the Page Models list after ${attempt + 1} loads`,
+                )
+            }
+            // deliberate pacing: the row is served from Oak's async index, which has no
+            // deterministic client-side signal to wait on.
+            // eslint-disable-next-line cypress/no-unnecessary-waiting
+            cy.wait(3000)
+            return openUntilRowPresent(attempt + 1)
         })
     }
 

--- a/tests/cypress/fixtures/groovy/createPageModelWithMarkupName.groovy
+++ b/tests/cypress/fixtures/groovy/createPageModelWithMarkupName.groovy
@@ -1,0 +1,37 @@
+import org.jahia.services.content.JCRCallback
+import org.jahia.services.content.JCRSessionWrapper
+import org.jahia.services.content.JCRTemplate
+import org.jahia.services.content.JCRNodeWrapper
+import org.jahia.api.Constants
+import javax.jcr.RepositoryException
+import java.util.Locale
+
+// Plant a template-model page (jnt:page + jmix:canBeUseAsTemplateModel) under the site whose NODE
+// NAME contains reserved markup characters. That node name flows verbatim into the "page path" column
+// of the Page Models administration screen. A node name set through addChild is sanitised, whereas a
+// JCR rename() is not; the fixture reproduces that by creating with a plain name then rename()-ing to
+// the raw markup name.
+//
+// Runs in the EDIT workspace + EN locale: the screen renders in edit/en and its list query joins the
+// EN translation, so the node must carry its mandatory i18n props (jcr:title, j:pageTemplateTitle) in
+// EN or it is filtered out of the list. Idempotent. Tokens replaced by cy.executeGroovy.
+JCRTemplate.getInstance().doExecuteWithSystemSessionAsUser(null, Constants.EDIT_WORKSPACE, Locale.ENGLISH, new JCRCallback() {
+    @Override
+    Object doInJCR(JCRSessionWrapper session) throws RepositoryException {
+        JCRNodeWrapper site = session.getNode("/sites/SITE_KEY")
+        String markupName = "MARKUP_NAME"
+        if (site.hasNode(markupName)) {
+            return null // already planted
+        }
+        JCRNodeWrapper page = site.addNode("pageModelProbe", "jnt:page")
+        page.addMixin("jmix:canBeUseAsTemplateModel")
+        page.setProperty("jcr:title", "Page model probe")
+        page.setProperty("j:pageTemplateTitle", "Page model probe") // mandatory i18n prop
+        page.setProperty("j:templateName", "home")
+        session.save()
+        page.rename(markupName)
+        session.save()
+        log.info("createPageModelWithNamePayload: " + page.getPath())
+        return null
+    }
+})

--- a/tests/cypress/fixtures/groovy/createPageModelWithMarkupName.groovy
+++ b/tests/cypress/fixtures/groovy/createPageModelWithMarkupName.groovy
@@ -23,6 +23,11 @@ JCRTemplate.getInstance().doExecuteWithSystemSessionAsUser(null, Constants.EDIT_
         if (site.hasNode(markupName)) {
             return null // already planted
         }
+        // truly idempotent: drop a probe left behind by a run that failed between addNode() and rename()
+        if (site.hasNode("pageModelProbe")) {
+            site.getNode("pageModelProbe").remove()
+            session.save()
+        }
         JCRNodeWrapper page = site.addNode("pageModelProbe", "jnt:page")
         page.addMixin("jmix:canBeUseAsTemplateModel")
         page.setProperty("jcr:title", "Page model probe")


### PR DESCRIPTION
## Summary

The Server Settings → **Page Models** list renders three columns — *page name*, *model name*
and *page path*. The page name and model name are emitted through JSTL
(`fn:escapeXml` / `<c:out>`), but the **page path** column is emitted via raw EL
(`${pageModel.path}`). A page path that contains reserved markup characters (for example `<`
or `>`, which a JCR node name may legitimately hold) is therefore rendered inconsistently with
the other two columns and can corrupt the surrounding table markup.

## Change

Wrap the page-path value in `<c:out>` in both the default view
(`siteSettingsManagePageModels.jsp`) and the `settingsBootstrap3GoogleMaterialStyle` variant,
mirroring the existing treatment of the *page name* and *model name* columns. Ordinary paths are
unaffected — only the rendering of reserved characters is made consistent across the three
columns.

## Verification

Added a self-contained Cypress regression (`managePageModelsDisplayEscaping.test.cy.ts` plus a
Groovy fixture) that creates a site and a template-model page whose node name contains reserved
markup characters, opens the Page Models screen, and asserts the path renders as literal text
(no live element). The spec **fails before** this change and **passes after** it. Verified
locally against Jahia 8.2.4.0-SNAPSHOT: module built with JDK 11, hot-deployed, spec run
headless.
