### PR TITLE
fix: render site settings components only for callers administering the resource

### DIFF
--- a/.chachalog/EKEnT.md
+++ b/.chachalog/EKEnT.md
@@ -1,0 +1,5 @@
+---
+siteSettings: patch
+---
+
+Render site settings components only for callers administering the resource

--- a/src/main/java/org/jahia/modules/sitesettings/render/SettingsComponentPermissionFilter.java
+++ b/src/main/java/org/jahia/modules/sitesettings/render/SettingsComponentPermissionFilter.java
@@ -13,6 +13,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+/*
+ * Wiring note — this is deliberately OSGi Declarative Services, not a Spring bean.
+ *
+ * Jahia's engineering conventions (the shared `cortex` harness, skill
+ * `jahia-java-osgi-declarative-services`) state the rule as: DS is the ONLY dependency-injection
+ * mechanism allowed in a Jahia module — Blueprint is deprecated and Spring is forbidden, with the sole
+ * tolerated exception being a guarded `SpringContextSingleton.getBean(...)` read-through to a core bean.
+ * An earlier revision of this filter was registered as a Spring bean in META-INF/spring; it was moved
+ * here to follow that rule, and the render filter it registers behaves identically either way (both end
+ * up in JahiaTemplateManagerService.getRenderFilters()).
+ *
+ * The same harness documents the trap to watch for if this is ever ported to another module: without the
+ * bnd instruction `<_dsannotations>*</_dsannotations>`, an @Component class compiles and ships but emits
+ * no OSGI-INF descriptor and no Service-Component header, so the component silently never registers and
+ * the gate below simply does not run. Parents `jahia-modules` >= 8.1.7.0 switch it on already; older ones
+ * do not. Verify a descriptor is actually in the built jar rather than assuming.
+ */
 package org.jahia.modules.sitesettings.render;
 
 import org.apache.commons.lang.StringUtils;
@@ -21,73 +38,92 @@ import org.jahia.services.render.RenderContext;
 import org.jahia.services.render.Resource;
 import org.jahia.services.render.filter.AbstractFilter;
 import org.jahia.services.render.filter.RenderChain;
+import org.jahia.services.render.filter.RenderFilter;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
 /**
- * Renders a settings component only when the caller holds an administration permission on the
- * resource the request is actually made against.
+ * Renders a settings component only when the caller holds an administration permission on the resource the
+ * request is actually made against.
  * <p>
- * The settings components of this module are ordinary, instantiable content types, so the container
- * they were designed for is not the only place they can end up being rendered from. The permission
- * requirements declared on the settings templates ({@code j:requiredPermissionNames}) are a property
- * of those templates, so a component rendered through any other resource carries no requirement at
- * all — and the flow behind it would then be handed to whoever can render that resource. This filter
- * makes the requirement a property of the component instead, so it holds on every render path.
+ * The site settings screens of this module are ordinary, instantiable content types, so the settings
+ * container they were designed for is not the only place they can be rendered from. The permission each
+ * screen requires is declared on the settings <em>template</em> that hosts it
+ * ({@code j:requiredPermissionNames}), so it is a property of that template and not of the component: the
+ * same component rendered through any other resource — a plain page content area — carries no requirement at
+ * all, and the Spring web flow behind it would be handed to whoever can render that resource. This filter
+ * makes the requirement a property of the component, so it holds on every render path.
  * <p>
- * The check is evaluated against the <strong>main resource</strong> of the render, not against the
- * component node: the component node of a settings screen lives inside the module
- * ({@code /modules/&lt;module&gt;/...}), where a site-scoped administrator holds nothing, while the
- * main resource is the site (site settings) or the global settings node (server administration) —
- * the very node the corresponding administrator role is granted on. Checking the component node
- * instead would refuse legitimate administrators.
+ * The check is evaluated against the <strong>main resource</strong> of the render, not against the component
+ * node, and that is load-bearing rather than incidental: the component node of a <em>legitimate</em> settings
+ * screen lives inside its module ({@code /modules/...}), where a site-scoped administrator holds nothing —
+ * measured, {@code site-admin} is {@code false} there and {@code true} on {@code /sites/<key>}. Checking
+ * the component node, which is the obvious implementation, would therefore refuse real site administrators.
+ * The main resource is the site (site-settings route) or the global settings node (server-administration
+ * route), which is what the corresponding administrator role is actually granted on.
  * <p>
- * Any one of the configured permissions is sufficient, since these components are reached from both
- * the site-scoped and the server-wide administration route. Failing to resolve a main resource, or a
- * missing configuration, yields an empty fragment rather than a rendered component.
+ * Either {@code site-admin} or {@code admin} is accepted, because these screens are reached from both the
+ * site-scoped and the server-wide administration route (serverSettings registers the user and group screens
+ * under {@code jnt:globalSettings}). Both are core permissions ({@code root-permissions.xml}) granted by the
+ * {@code site-administrator} / {@code server-administrator} roles; the finer per-screen permissions are
+ * contributed by this module's own {@code permissions.xml} and resolve to {@code false} indistinguishably
+ * from a denial where they are not registered, which would fail closed for administrators too.
+ * The finer per-screen requirement declared on the settings template remains enforced on the administration
+ * route, so this filter is an additional condition and never a replacement. Failing to resolve a main resource
+ * yields an empty fragment rather than a rendered component.
+ * <p>
+ * Registered via OSGi Declarative Services — no Spring context involvement.
  */
-// equals/hashCode are deliberately NOT overridden for the field below: AbstractFilter defines
-// equality as (concrete class, priority), which is the key RenderService.addFilter uses to replace an
-// already-registered filter. Widening it to the configuration would break that re-registration.
-@SuppressWarnings("java:S2160")
+@Component(service = RenderFilter.class, immediate = true)
 public class SettingsComponentPermissionFilter extends AbstractFilter {
 
     private static final Logger logger = LoggerFactory.getLogger(SettingsComponentPermissionFilter.class);
 
-    private String[] requiredPermissions = new String[0];
-    private String requiredPermissionsLabel = "";
+    /** Node types gated by this filter. */
+    private static final String APPLY_ON_NODE_TYPES = 
+            "jnt:siteSettingsManageUsers," +
+            "jnt:siteSettingsManageGroups," +
+            "jnt:siteSettingsManageModules," +
+            "jnt:siteSettingsManagePageModels," +
+            "jnt:siteSettingsWcagCompliance," +
+            "jnt:siteSettingsHtmlFiltering";
 
-    /**
-     * Sets the permissions accepted by this filter, as a comma-separated list. A caller holding any
-     * one of them on the main resource may render the component.
-     *
-     * @param requiredPermissions comma-separated list of permission names
-     */
-    public void setRequiredPermissions(String requiredPermissions) {
-        String[] parsed = StringUtils.split(StringUtils.defaultString(requiredPermissions), ',');
-        for (int i = 0; i < parsed.length; i++) {
-            parsed[i] = parsed[i].trim();
-        }
-        this.requiredPermissions = parsed;
-        this.requiredPermissionsLabel = StringUtils.join(parsed, ", ");
+    /** Any one of these on the main resource is sufficient. */
+    private static final List<String> REQUIRED_PERMISSIONS =
+            Collections.unmodifiableList(Arrays.asList("site-admin", "admin"));
+
+    private static final String REQUIRED_PERMISSIONS_LABEL = StringUtils.join(REQUIRED_PERMISSIONS, ", ");
+
+    @Activate
+    public void activate() {
+        // Priority 22: immediately after core's own permission check (TemplatePermissionCheckFilter, 21) and
+        // before the fragment is produced or cached — a refusal must not populate a cache entry that a
+        // differently-privileged caller could later be served.
+        setPriority(22);
+        setApplyOnNodeTypes(APPLY_ON_NODE_TYPES);
+        setDescription("Renders a settings component only for a caller holding an administration permission "
+                + "on the main resource");
+        logger.debug("SettingsComponentPermissionFilter active on {}", APPLY_ON_NODE_TYPES);
     }
 
     @Override
     public String prepare(RenderContext renderContext, Resource resource, RenderChain chain) throws Exception {
-        if (requiredPermissions.length == 0) {
-            logger.error("No permission configured for {}; refusing to render {}",
-                    getClass().getName(), resource.getNodePath());
-            return StringUtils.EMPTY;
-        }
-
         Resource mainResource = renderContext.getMainResource();
         JCRNodeWrapper contextNode = mainResource != null ? mainResource.getNode() : null;
         if (contextNode == null) {
+            // Fail closed: with no main resource there is nothing to evaluate the permission against, and this
+            // is an administration capability.
             logger.warn("No main resource to evaluate {} against; not rendering it", resource.getNodePath());
             return StringUtils.EMPTY;
         }
 
-        for (String permission : requiredPermissions) {
+        for (String permission : REQUIRED_PERMISSIONS) {
             if (contextNode.hasPermission(permission)) {
                 return null;
             }
@@ -96,7 +132,7 @@ public class SettingsComponentPermissionFilter extends AbstractFilter {
         if (logger.isWarnEnabled()) {
             logger.warn("Not rendering {}: {} holds none of {} on {}", resource.getNodePath(),
                     renderContext.getUser() != null ? renderContext.getUser().getName() : "the current user",
-                    requiredPermissionsLabel, contextNode.getPath());
+                    REQUIRED_PERMISSIONS_LABEL, contextNode.getPath());
         }
         return StringUtils.EMPTY;
     }

--- a/src/main/java/org/jahia/modules/sitesettings/render/SettingsComponentPermissionFilter.java
+++ b/src/main/java/org/jahia/modules/sitesettings/render/SettingsComponentPermissionFilter.java
@@ -52,13 +52,11 @@ import java.util.List;
  * Renders a settings component only when the caller holds an administration permission on the resource the
  * request is actually made against.
  * <p>
- * The site settings screens of this module are ordinary, instantiable content types, so the settings
- * container they were designed for is not the only place they can be rendered from. The permission each
- * screen requires is declared on the settings <em>template</em> that hosts it
- * ({@code j:requiredPermissionNames}), so it is a property of that template and not of the component: the
- * same component rendered through any other resource — a plain page content area — carries no requirement at
- * all, and the Spring web flow behind it would be handed to whoever can render that resource. This filter
- * makes the requirement a property of the component, so it holds on every render path.
+ * The permission requirement belongs on the component, not only on the settings template that normally
+ * hosts it ({@code j:requiredPermissionNames}): a component's access rule should travel with the component
+ * and hold on every render path, regardless of where the component is placed. This filter makes the
+ * requirement a property of the component so it applies uniformly. Because {@code WebflowAction} re-enters
+ * the render chain for each webflow POST, it covers every transition too, not just the initial GET.
  * <p>
  * The check is evaluated against the <strong>main resource</strong> of the render, not against the component
  * node, and that is load-bearing rather than incidental: the component node of a <em>legitimate</em> settings

--- a/src/main/java/org/jahia/modules/sitesettings/render/SettingsComponentPermissionFilter.java
+++ b/src/main/java/org/jahia/modules/sitesettings/render/SettingsComponentPermissionFilter.java
@@ -100,10 +100,14 @@ public class SettingsComponentPermissionFilter extends AbstractFilter {
 
     @Activate
     public void activate() {
-        // Priority 22: immediately after core's own permission check (TemplatePermissionCheckFilter, 21) and
-        // before the fragment is produced or cached — a refusal must not populate a cache entry that a
-        // differently-privileged caller could later be served.
-        setPriority(22);
+        // Priority 21.5: immediately after core's own permission check (TemplatePermissionCheckFilter, 21) and
+        // clear of the 22.x template band. AbstractFilter breaks a priority tie on the class name, so an exact
+        // 22 would order this against core's templateNodeFilter (22.0) by an accident of package naming rather
+        // than by intent; 21.5 states the intended slot instead of relying on that.
+        // This runs inside the fragment cache's generation scope (live only, 16 / 16.5), which is safe because
+        // that cache keys on the caller's ACL signature: an entry generated for an administrator is not served
+        // to a caller who lacks the grant.
+        setPriority(21.5f);
         setApplyOnNodeTypes(APPLY_ON_NODE_TYPES);
         setDescription("Renders a settings component only for a caller holding an administration permission "
                 + "on the main resource");

--- a/src/main/java/org/jahia/modules/sitesettings/render/SettingsComponentPermissionFilter.java
+++ b/src/main/java/org/jahia/modules/sitesettings/render/SettingsComponentPermissionFilter.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2002-2022 Jahia Solutions Group SA. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jahia.modules.sitesettings.render;
+
+import org.apache.commons.lang.StringUtils;
+import org.jahia.services.content.JCRNodeWrapper;
+import org.jahia.services.render.RenderContext;
+import org.jahia.services.render.Resource;
+import org.jahia.services.render.filter.AbstractFilter;
+import org.jahia.services.render.filter.RenderChain;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Renders a settings component only when the caller holds an administration permission on the
+ * resource the request is actually made against.
+ * <p>
+ * The settings components of this module are ordinary, instantiable content types, so the container
+ * they were designed for is not the only place they can end up being rendered from. The permission
+ * requirements declared on the settings templates ({@code j:requiredPermissionNames}) are a property
+ * of those templates, so a component rendered through any other resource carries no requirement at
+ * all — and the flow behind it would then be handed to whoever can render that resource. This filter
+ * makes the requirement a property of the component instead, so it holds on every render path.
+ * <p>
+ * The check is evaluated against the <strong>main resource</strong> of the render, not against the
+ * component node: the component node of a settings screen lives inside the module
+ * ({@code /modules/&lt;module&gt;/...}), where a site-scoped administrator holds nothing, while the
+ * main resource is the site (site settings) or the global settings node (server administration) —
+ * the very node the corresponding administrator role is granted on. Checking the component node
+ * instead would refuse legitimate administrators.
+ * <p>
+ * Any one of the configured permissions is sufficient, since these components are reached from both
+ * the site-scoped and the server-wide administration route. Failing to resolve a main resource, or a
+ * missing configuration, yields an empty fragment rather than a rendered component.
+ */
+public class SettingsComponentPermissionFilter extends AbstractFilter {
+
+    private static final Logger logger = LoggerFactory.getLogger(SettingsComponentPermissionFilter.class);
+
+    private String[] requiredPermissions = new String[0];
+
+    /**
+     * Sets the permissions accepted by this filter, as a comma-separated list. A caller holding any
+     * one of them on the main resource may render the component.
+     *
+     * @param requiredPermissions comma-separated list of permission names
+     */
+    public void setRequiredPermissions(String requiredPermissions) {
+        String[] parsed = StringUtils.split(StringUtils.defaultString(requiredPermissions), ',');
+        for (int i = 0; i < parsed.length; i++) {
+            parsed[i] = parsed[i].trim();
+        }
+        this.requiredPermissions = parsed;
+    }
+
+    @Override
+    public String prepare(RenderContext renderContext, Resource resource, RenderChain chain) throws Exception {
+        if (requiredPermissions.length == 0) {
+            logger.error("No permission configured for {}; refusing to render {}",
+                    getClass().getName(), resource.getNodePath());
+            return StringUtils.EMPTY;
+        }
+
+        Resource mainResource = renderContext.getMainResource();
+        JCRNodeWrapper contextNode = mainResource != null ? mainResource.getNode() : null;
+        if (contextNode == null) {
+            logger.warn("No main resource to evaluate {} against; not rendering it", resource.getNodePath());
+            return StringUtils.EMPTY;
+        }
+
+        for (String permission : requiredPermissions) {
+            if (contextNode.hasPermission(permission)) {
+                return null;
+            }
+        }
+
+        logger.warn("Not rendering {}: {} holds none of {} on {}", resource.getNodePath(),
+                renderContext.getUser() != null ? renderContext.getUser().getName() : "the current user",
+                StringUtils.join(requiredPermissions, ", "), contextNode.getPath());
+        return StringUtils.EMPTY;
+    }
+}

--- a/src/main/java/org/jahia/modules/sitesettings/render/SettingsComponentPermissionFilter.java
+++ b/src/main/java/org/jahia/modules/sitesettings/render/SettingsComponentPermissionFilter.java
@@ -46,11 +46,16 @@ import org.slf4j.LoggerFactory;
  * the site-scoped and the server-wide administration route. Failing to resolve a main resource, or a
  * missing configuration, yields an empty fragment rather than a rendered component.
  */
+// equals/hashCode are deliberately NOT overridden for the field below: AbstractFilter defines
+// equality as (concrete class, priority), which is the key RenderService.addFilter uses to replace an
+// already-registered filter. Widening it to the configuration would break that re-registration.
+@SuppressWarnings("java:S2160")
 public class SettingsComponentPermissionFilter extends AbstractFilter {
 
     private static final Logger logger = LoggerFactory.getLogger(SettingsComponentPermissionFilter.class);
 
     private String[] requiredPermissions = new String[0];
+    private String requiredPermissionsLabel = "";
 
     /**
      * Sets the permissions accepted by this filter, as a comma-separated list. A caller holding any
@@ -64,6 +69,7 @@ public class SettingsComponentPermissionFilter extends AbstractFilter {
             parsed[i] = parsed[i].trim();
         }
         this.requiredPermissions = parsed;
+        this.requiredPermissionsLabel = StringUtils.join(parsed, ", ");
     }
 
     @Override
@@ -87,9 +93,11 @@ public class SettingsComponentPermissionFilter extends AbstractFilter {
             }
         }
 
-        logger.warn("Not rendering {}: {} holds none of {} on {}", resource.getNodePath(),
-                renderContext.getUser() != null ? renderContext.getUser().getName() : "the current user",
-                StringUtils.join(requiredPermissions, ", "), contextNode.getPath());
+        if (logger.isWarnEnabled()) {
+            logger.warn("Not rendering {}: {} holds none of {} on {}", resource.getNodePath(),
+                    renderContext.getUser() != null ? renderContext.getUser().getName() : "the current user",
+                    requiredPermissionsLabel, contextNode.getPath());
+        }
         return StringUtils.EMPTY;
     }
 }

--- a/src/main/resources/META-INF/spring/site-settings.xml
+++ b/src/main/resources/META-INF/spring/site-settings.xml
@@ -12,16 +12,4 @@
         <entry key="memberDisplayLimit" value="${jahia.settings.memberDisplayLimit:100}"/>
     </util:map>
 
-    <!-- The settings components are reached from the site-scoped administration route (main resource:
-         the site) and from the server-wide one (main resource: the global settings node), so either
-         administration permission is accepted. -->
-    <bean id="siteSettingsComponentPermissionFilter"
-          class="org.jahia.modules.sitesettings.render.SettingsComponentPermissionFilter">
-        <property name="priority" value="22"/>
-        <property name="description"
-                  value="Renders a site settings component only for a caller holding an administration permission on the main resource"/>
-        <property name="applyOnNodeTypes"
-                  value="jnt:siteSettingsManageUsers,jnt:siteSettingsManageGroups,jnt:siteSettingsManageModules,jnt:siteSettingsManagePageModels,jnt:siteSettingsWcagCompliance,jnt:siteSettingsHtmlFiltering"/>
-        <property name="requiredPermissions" value="site-admin,admin"/>
-    </bean>
 </beans>

--- a/src/main/resources/META-INF/spring/site-settings.xml
+++ b/src/main/resources/META-INF/spring/site-settings.xml
@@ -11,4 +11,17 @@
         <entry key="userDisplayLimit" value="${jahia.settings.userDisplayLimit:100}"/>
         <entry key="memberDisplayLimit" value="${jahia.settings.memberDisplayLimit:100}"/>
     </util:map>
+
+    <!-- The settings components are reached from the site-scoped administration route (main resource:
+         the site) and from the server-wide one (main resource: the global settings node), so either
+         administration permission is accepted. -->
+    <bean id="siteSettingsComponentPermissionFilter"
+          class="org.jahia.modules.sitesettings.render.SettingsComponentPermissionFilter">
+        <property name="priority" value="22"/>
+        <property name="description"
+                  value="Renders a site settings component only for a caller holding an administration permission on the main resource"/>
+        <property name="applyOnNodeTypes"
+                  value="jnt:siteSettingsManageUsers,jnt:siteSettingsManageGroups,jnt:siteSettingsManageModules,jnt:siteSettingsManagePageModels,jnt:siteSettingsWcagCompliance,jnt:siteSettingsHtmlFiltering"/>
+        <property name="requiredPermissions" value="site-admin,admin"/>
+    </bean>
 </beans>

--- a/src/main/resources/META-INF/spring/site-settings.xml
+++ b/src/main/resources/META-INF/spring/site-settings.xml
@@ -11,5 +11,4 @@
         <entry key="userDisplayLimit" value="${jahia.settings.userDisplayLimit:100}"/>
         <entry key="memberDisplayLimit" value="${jahia.settings.memberDisplayLimit:100}"/>
     </util:map>
-
 </beans>

--- a/tests/cypress/e2e/settingsComponentRenderScope.test.cy.ts
+++ b/tests/cypress/e2e/settingsComponentRenderScope.test.cy.ts
@@ -20,6 +20,7 @@ describe('Site settings components - render scope', () => {
     const site = 'renderScope' + uniq
 
     const siteAdmin = 'renderscopeadmin' + uniq // administers the site
+    const serverAdmin = 'renderscopesrvadmin' + uniq // administers the whole server
     const lowPriv = 'renderscopelow' + uniq // ordinary account, administers nothing
 
     // the settings component, placed OUTSIDE the settings container
@@ -30,17 +31,24 @@ describe('Site settings components - render scope', () => {
 
     // accounts the component's own creation flow would produce if it were served and driven
     const byAdmin = 'renderscopebyadmin' + uniq
+    const bySrvAdmin = 'renderscopebysrvadmin' + uniq
     const byLowPriv = 'renderscopebylow' + uniq
 
     before(() => {
         createSite(site, { languages: 'en', templateSet: 'templates-system', serverName: 'localhost', locale: 'en' })
 
         createUser(siteAdmin, 'password', [{ name: 'j:firstName', value: 'admin' }])
+        createUser(serverAdmin, 'password', [{ name: 'j:firstName', value: 'srvadmin' }])
         createUser(lowPriv, 'password', [{ name: 'j:firstName', value: 'low' }])
 
         // the administrator administers this site; the low-privilege user only gets to read/edit content
         grantRoles(`/sites/${site}`, ['site-administrator'], siteAdmin, 'USER')
         grantRoles(`/sites/${site}`, ['editor'], lowPriv, 'USER')
+        // granted at the root, so this caller holds `admin` — the filter's other accepted permission — on the
+        // site that is the main resource of the render below. It also needs to be able to READ the hosting
+        // page, or its positive control would measure the site's read ACL instead of the component.
+        grantRoles('/', ['server-administrator'], serverAdmin, 'USER')
+        grantRoles(`/sites/${site}`, ['editor'], serverAdmin, 'USER')
 
         // an ordinary content area on the home page, then the settings component inside it
         addNode({ parentPathOrId: `/sites/${site}/home`, primaryNodeType: 'jnt:contentList', name: 'pagecontent' })
@@ -49,8 +57,9 @@ describe('Site settings components - render scope', () => {
 
     after(() => {
         cy.login()
-        ;[byAdmin, byLowPriv].forEach((name) => userPath(name).then((p) => p && deleteUser(name)))
+        ;[byAdmin, bySrvAdmin, byLowPriv].forEach((name) => userPath(name).then((p) => p && deleteUser(name)))
         deleteUser(siteAdmin)
+        deleteUser(serverAdmin)
         deleteUser(lowPriv)
         deleteSite(site)
     })
@@ -165,6 +174,22 @@ describe('Site settings components - render scope', () => {
         cy.login()
         userPath(byAdmin).then((path) => {
             expect(path, 'the administrator must still be able to create a user through the component').to.not.be.null
+        })
+    })
+
+    // The filter accepts either accepted permission, so each one needs its own positive control: with only the
+    // site-scoped case asserted, `admin` could be the wrong permission and this spec would stay green while
+    // server administrators were refused.
+    it('serves the placed component and creates a user for the server administrator (positive control)', () => {
+        cy.login(serverAdmin, 'password')
+        attemptCreate(bySrvAdmin).then((outcome: { served: number; reached: boolean }) => {
+            expect(outcome.served, 'the server administrator must still be served the flow').to.be.greaterThan(0)
+            expect(outcome.reached, 'the server administrator must still reach the creation form').to.be.true
+        })
+        cy.login()
+        userPath(bySrvAdmin).then((path) => {
+            expect(path, 'the server administrator must still be able to create a user through the component').to.not.be
+                .null
         })
     })
 

--- a/tests/cypress/e2e/settingsComponentRenderScope.test.cy.ts
+++ b/tests/cypress/e2e/settingsComponentRenderScope.test.cy.ts
@@ -1,0 +1,188 @@
+// Render scope of the site settings components. These screens are ordinary, instantiable content
+// types, so the settings container they were designed for is not the only place they can be rendered
+// from. This spec places one of them in a plain page content area — i.e. outside that container — and
+// asserts that the web flow behind it, and the user creation it performs, are only available to a
+// caller that actually administers the site. Opaque by design.
+//
+// Non-vacuity: every negative assertion is paired with a POSITIVE CONTROL that goes through the exact
+// same request shape and asserts the flow IS served, and a user IS created, for the site
+// administrator. A fixture that simply renders nothing, or a driver that posts the wrong shape,
+// therefore cannot produce a false green. A first test also proves the low-privilege session is
+// authenticated and can read the page it renders, so a refusal is a refusal and not a read failure.
+//
+// Fully self-contained: creates its own site, the site administrator, the low-privilege user and the
+// placed component in before(); tears everything down in after().
+import { createSite, deleteSite, createUser, deleteUser, grantRoles, addNode } from '@jahia/cypress'
+import { generateRandomID } from '../utils/utils'
+
+describe('Site settings components - render scope', () => {
+    const uniq = generateRandomID().replace(/[^a-z0-9]/gi, '')
+    const site = 'renderScope' + uniq
+
+    const siteAdmin = 'renderscopeadmin' + uniq // administers the site
+    const lowPriv = 'renderscopelow' + uniq // ordinary account, administers nothing
+
+    // the settings component, placed OUTSIDE the settings container
+    const placed = 'placedManageUsers' + uniq
+    const area = `/sites/${site}/home/pagecontent`
+    // the page that hosts it — this is the URL that gets rendered
+    const pageUrl = `/cms/render/default/en/sites/${site}/home.html`
+
+    // accounts the component's own creation flow would produce if it were served and driven
+    const byAdmin = 'renderscopebyadmin' + uniq
+    const byLowPriv = 'renderscopebylow' + uniq
+
+    before(() => {
+        createSite(site, { languages: 'en', templateSet: 'templates-system', serverName: 'localhost', locale: 'en' })
+
+        createUser(siteAdmin, 'password', [{ name: 'j:firstName', value: 'admin' }])
+        createUser(lowPriv, 'password', [{ name: 'j:firstName', value: 'low' }])
+
+        // the administrator administers this site; the low-privilege user only gets to read/edit content
+        grantRoles(`/sites/${site}`, ['site-administrator'], siteAdmin, 'USER')
+        grantRoles(`/sites/${site}`, ['editor'], lowPriv, 'USER')
+
+        // an ordinary content area on the home page, then the settings component inside it
+        addNode({ parentPathOrId: `/sites/${site}/home`, primaryNodeType: 'jnt:contentList', name: 'pagecontent' })
+        addNode({ parentPathOrId: area, primaryNodeType: 'jnt:siteSettingsManageUsers', name: placed })
+    })
+
+    after(() => {
+        cy.login()
+        ;[byAdmin, byLowPriv].forEach((name) => userPath(name).then((p) => p && deleteUser(name)))
+        deleteUser(siteAdmin)
+        deleteUser(lowPriv)
+        deleteSite(site)
+    })
+
+    // ---- out-of-band verification, as root, independent of the driving session ----
+
+    const userPath = (name: string) =>
+        cy
+            .request({
+                method: 'POST',
+                url: '/modules/graphql',
+                headers: { Origin: Cypress.config().baseUrl as string },
+                auth: { username: 'root', password: Cypress.env('SUPER_USER_PASSWORD') as string },
+                body: {
+                    query: `{jcr(workspace:EDIT){q:nodesByQuery(query:"select * from [jnt:user] where localname()='${name}'"){nodes{path}}}}`,
+                },
+            })
+            .then((res) => (res.body?.data?.jcr?.q?.nodes?.[0]?.path ?? null) as string | null)
+
+    // ---- driving the component the way its own screen does ----
+
+    // The action URL of the screen's hidden users form carries the flow execution key; without a
+    // served flow there is no such form and nothing can be driven.
+    const usersFormAction = (body: string): string | null => {
+        const forms = body.match(/<form[^>]*>/g) || []
+        const form = forms.find((f) => f.includes('usersForm'))
+        const action = form && form.match(/action="([^"]+)"/)
+        return action ? action[1].replace(/&amp;/g, '&') : null
+    }
+
+    const formContaining = (body: string, needle: string): string | null => {
+        const forms = body.match(/<form[^>]*>[\s\S]*?<\/form>/g) || []
+        return forms.find((f) => f.includes(needle)) ?? null
+    }
+
+    const render = (url: string) =>
+        cy
+            .request({ url, failOnStatusCode: false, qs: { ec: generateRandomID() } })
+            .then((res) => (typeof res.body === 'string' ? res.body : ''))
+
+    // Attempts the component's user-creation flow as whoever is currently logged in. Resolves to the
+    // number of flow execution keys the render served, so the caller can assert on exposure too.
+    const attemptCreate = (username: string) =>
+        render(pageUrl).then((body) => {
+            const served = (body.match(/webflowexecution/g) || []).length
+            const action = usersFormAction(body)
+            if (!action) {
+                return cy.wrap({ served, reached: false })
+            }
+            return cy
+                .request({
+                    method: 'POST',
+                    url: action,
+                    form: true,
+                    failOnStatusCode: false,
+                    body: { _eventId: 'addUser' },
+                })
+                .then((res) => {
+                    const createForm = formContaining(typeof res.body === 'string' ? res.body : '', 'name="username"')
+                    if (!createForm) {
+                        return cy.wrap({ served, reached: false })
+                    }
+                    const a = createForm.match(/action="([^"]+)"/)
+                    const target = a ? a[1].replace(/&amp;/g, '&') : action
+                    return cy
+                        .request({
+                            method: 'POST',
+                            url: target,
+                            form: true,
+                            failOnStatusCode: false,
+                            body: {
+                                username,
+                                password: 'Passw0rd!1',
+                                passwordConfirm: 'Passw0rd!1',
+                                preferredLanguage: 'en',
+                                accountLocked: 'false',
+                                emailNotificationsDisabled: 'false',
+                                firstName: 'render',
+                                lastName: 'scope',
+                                email: 'renderscope@example.invalid',
+                                organization: '',
+                                _eventId: 'add',
+                            },
+                        })
+                        .then(() => cy.wrap({ served, reached: true }))
+                })
+        })
+
+    it('the low-privilege session is authenticated and can read the hosting page', () => {
+        cy.login(lowPriv, 'password')
+        cy.request({
+            method: 'POST',
+            url: '/modules/graphql',
+            headers: { Origin: Cypress.config().baseUrl as string },
+            body: { query: '{currentUser{name}}' },
+        }).then((res) => {
+            expect(res.body?.data?.currentUser?.name, 'the driving session must be the low-privilege account').to.eq(
+                lowPriv,
+            )
+        })
+        cy.request({ url: pageUrl, qs: { ec: generateRandomID() } }).then((res) => {
+            expect(res.status, 'the low-privilege account must be able to read the hosting page').to.eq(200)
+        })
+    })
+
+    it('serves the placed component and creates a user for the site administrator (positive control)', () => {
+        cy.login(siteAdmin, 'password')
+        attemptCreate(byAdmin).then((outcome: { served: number; reached: boolean }) => {
+            expect(outcome.served, 'the administrator must still be served the flow').to.be.greaterThan(0)
+            expect(outcome.reached, 'the administrator must still reach the creation form').to.be.true
+        })
+        cy.login()
+        userPath(byAdmin).then((path) => {
+            expect(path, 'the administrator must still be able to create a user through the component').to.not.be.null
+        })
+    })
+
+    it('serves nothing and creates no user for a caller that administers nothing', () => {
+        cy.login()
+        userPath(byLowPriv).then((existing) => {
+            expect(existing, 'baseline: the account must not exist yet').to.be.null
+        })
+
+        cy.login(lowPriv, 'password')
+        attemptCreate(byLowPriv).then((outcome: { served: number; reached: boolean }) => {
+            expect(outcome.served, 'no flow may be served to a caller that administers nothing').to.eq(0)
+            expect(outcome.reached, 'the creation form must not be reachable').to.be.false
+        })
+
+        cy.login()
+        userPath(byLowPriv).then((path) => {
+            expect(path, 'no account may be created through the placed component').to.be.null
+        })
+    })
+})

--- a/tests/cypress/e2e/settingsComponentRenderScope.test.cy.ts
+++ b/tests/cypress/e2e/settingsComponentRenderScope.test.cy.ts
@@ -1,8 +1,8 @@
-// Render scope of the site settings components. These screens are ordinary, instantiable content
-// types, so the settings container they were designed for is not the only place they can be rendered
-// from. This spec places one of them in a plain page content area — i.e. outside that container — and
-// asserts that the web flow behind it, and the user creation it performs, are only available to a
-// caller that actually administers the site. Opaque by design.
+// Render scope of the site settings components. A component's access rule should travel with the
+// component and hold on every render path, regardless of where the component is placed — not only on the
+// settings template that normally hosts it. This spec renders one of these components through an ordinary
+// resource and asserts that its web flow, and the user creation it performs, remain available only to a
+// caller that administers the site.
 //
 // Non-vacuity: every negative assertion is paired with a POSITIVE CONTROL that goes through the exact
 // same request shape and asserts the flow IS served, and a user IS created, for the site


### PR DESCRIPTION
## Summary

The permission requirement belongs on the **component**, not only on the settings template that normally
hosts it (`j:requiredPermissionNames`): a component's access rule should travel with the component and hold on
every render path, regardless of where the component is placed. This module's settings screens are ordinary, instantiable content types, so the requirement is made a property of each component.

## Change

A render filter (`SettingsComponentPermissionFilter`, priority 21.5) applied on this module's six `jnt:siteSettings*` node types, registered via
**OSGi Declarative Services**. When the caller holds none of the accepted permissions it returns an empty
fragment — core's own semantics in `TemplatePermissionCheckFilter`. Because `WebflowAction` re-enters the
render chain for each webflow POST, every transition is covered too, not just the initial GET.

**The check is evaluated on the render's MAIN RESOURCE, not on the component node.** This is the
counter-intuitive part and it is load-bearing: the component node of a legitimate settings screen lives inside
its module (`/modules/...`), where a site-scoped administrator holds nothing — measured, `site-admin` is
`false` there and `true` on `/sites/<key>`. Checking the component node, which is the obvious implementation,
would refuse real site administrators. The main resource is the site (site-settings route) or the global
settings node (server-administration route), which is what each administrator role is granted on.

Either `site-admin` or `admin` is accepted: this screen is reached from both administration routes, so a
site-scoped administrator is a legitimate caller. Both are core permissions (`root-permissions.xml`) granted by
the `site-administrator` / `server-administrator` roles. The finer per-screen permissions are contributed by a
module's own `permissions.xml` and resolve to `false` where they are not registered on an instance, which would
fail closed for administrators too; the finer requirement still applies on the administration route via the
template, so this is an additional condition and never a replacement.

## Verification

Measured on 8.2.4.0-SNAPSHOT, counting the Spring WebFlow execution keys a render serves (without one there is
no flow to drive):

| caller | flow served |
|---|---|
| `root` | yes |
| server administrator | yes |
| administrator of the hosting site | **yes** — a legitimate caller for this screen |
| ordinary editor | no |

Controls, so the negatives mean what they say: every caller in the table can read the hosting page (HTTP 200),
so a "no" is a permission decision and not an unreadable node; `root` cannot be refused by this mechanism at
all, since core short-circuits permission checks for administrators; and a server administrator is unaffected
throughout, which is the no-over-blocking control. A self-contained Cypress spec asserts the same invariant in CI, with each negative paired to a positive control that goes through the identical request shape.

## Notes

- Registered via DS rather than a Spring bean, per Jahia's convention that DS is the only DI mechanism for
  module code. Both routes register into `JahiaTemplateManagerService.getRenderFilters()`; verified live at
  priority 22, which is the value that measurement was taken at (see the priority note below).
- `equals`/`hashCode` are deliberately not overridden: `AbstractFilter` defines equality as
  (concrete class, priority), which is the key `RenderService.addFilter` uses to replace an already-registered
  filter. Widening it would break that re-registration.
- Studio rendering is not special-cased: core skips its own permission checks in `studiomode`, this filter does
  not. A template developer previewing the component in studio without an administration permission will get an
  empty fragment.

- Placement is deliberately left unconstrained in the nodetype definitions. The condition holds wherever the
  component renders — which is exactly what the off-container placement in the spec exercises — so a
  definition-level restriction would be belt-and-braces rather than the load-bearing control. Recorded here so
  it does not read as an oversight.
- Priority is 21.5, not 22. An exact 22 tied with core's `templateNodeFilter` (22.0); `AbstractFilter` breaks
  such a tie on the class name, so the resulting order held by an accident of package naming. 21.5 states the
  intended slot — immediately after core's permission check at 21, clear of the 22.x template band — directly.
  No behavioural change: 22 already ordered ahead of `templateNodeFilter`.
