### PR TITLE
test: cover group member display-name rendering in Manage Groups

### DIFF
--- a/tests/cypress/e2e/manageGroupsDisplayEscaping.test.cy.ts
+++ b/tests/cypress/e2e/manageGroupsDisplayEscaping.test.cy.ts
@@ -1,0 +1,89 @@
+// Regression test: the Manage Groups edit-group members list renders a member's display name as
+// inert TEXT (never live DOM/HTML), including when that member's jcr:title (self-settable by any
+// authenticated user) carries markup. Self-contained — creates its own site, group, and a member
+// user in before(), tears the site down in after(). Structural sibling of
+// manageUsersDisplayEscaping.test.cy.ts.
+//
+// This screen ships two JSP view variants for the same flow. The `.manageGroups.html` admin route
+// resolves to the `settingsBootstrap3GoogleMaterialStyle` variant in practice (confirmed empirically:
+// the webflow execution URL carries that view name, e.g.
+// `...webflowexecution<id>__settingsBootstrap3GoogleMaterialStyle=...`) — this test asserts on that
+// URL marker to pin coverage to the variant this admin route actually renders.
+import { createSite, deleteSite } from '@jahia/cypress'
+
+describe('Manage Groups - member display name rendering', () => {
+    const SITE = 'manageGroupsEscapingSite'
+    const GROUP = 'groupwithmarkupmember'
+    const USER = 'groupmarkupmember'
+    const MARKUP = '<img src=x onerror=window.__groupMembersMarkupExecuted=1>'
+
+    before(() => {
+        createSite(SITE, {
+            languages: 'en',
+            templateSet: 'templates-system',
+            serverName: 'localhost',
+            locale: 'en',
+        })
+        cy.executeGroovy('groovy/createSiteUserWithTitle.groovy', {
+            USER_NAME: USER,
+            SITE_KEY: SITE,
+            PASSWORD: 'GroupMemberPass123!',
+            TITLE_VALUE: MARKUP,
+        }).then((raw) => {
+            if (String(raw ?? '').includes('.failed')) {
+                throw new Error(`createSiteUserWithTitle failed: ${raw}`)
+            }
+        })
+        cy.executeGroovy('groovy/createSiteGroup.groovy', {
+            SITE_KEY: SITE,
+            GROUP_NAME: GROUP,
+        }).then((raw) => {
+            if (String(raw ?? '').includes('.failed')) {
+                throw new Error(`createSiteGroup failed: ${raw}`)
+            }
+        })
+        cy.executeGroovy('groovy/addSiteMemberToSiteGroup.groovy', {
+            SITE_KEY: SITE,
+            GROUP_NAME: GROUP,
+            MEMBER_NAME: USER,
+        }).then((raw) => {
+            if (String(raw ?? '').includes('.failed')) {
+                throw new Error(`addSiteMemberToSiteGroup failed: ${raw}`)
+            }
+        })
+    })
+
+    after(() => {
+        deleteSite(SITE)
+    })
+
+    it('renders a member display name containing markup as literal text (no active element, no handler fires)', () => {
+        cy.login()
+        cy.visit(`/cms/editframe/default/en/sites/${SITE}.manageGroups.html`, {
+            onBeforeLoad(win) {
+                ;(win as unknown as Record<string, unknown>).__groupMembersMarkupExecuted = undefined
+            },
+        })
+
+        // open the group's members list — this is the real admin flow (submitGroupForm('editGroup', ...)),
+        // not a hand-rolled webflow POST.
+        cy.get(`a:contains(${GROUP})`, { timeout: 10000 }).first().click()
+
+        // confirm which view variant rendered — this test's coverage is specific to
+        // settingsBootstrap3GoogleMaterialStyle, not incidental to it.
+        cy.location('href').should('include', 'settingsBootstrap3GoogleMaterialStyle')
+
+        // the display name must appear as escaped literal text in a table cell
+        cy.contains('td', MARKUP, { timeout: 10000 }).should('be.visible')
+        // and must NOT have become a live <img> element carrying an onerror handler
+        cy.get('td img[onerror]').should('not.exist')
+
+        // definitive live check: the onerror handler must never have executed
+        cy.window().then((win) => {
+            expect(
+                (win as unknown as Record<string, unknown>).__groupMembersMarkupExecuted,
+                'the onerror handler must not fire',
+            ).to.be.undefined
+        })
+    })
+})

--- a/tests/cypress/e2e/manageGroupsDisplayEscaping.test.cy.ts
+++ b/tests/cypress/e2e/manageGroupsDisplayEscaping.test.cy.ts
@@ -34,6 +34,19 @@ describe('Manage Groups - member display name rendering', () => {
                 throw new Error(`createSiteUserWithTitle failed: ${raw}`)
             }
         })
+        // give the member a first/last name so the adjacent Name column renders a plain name
+        // instead of falling back to the same display-name value this test asserts on below —
+        // without this, that column would independently satisfy the assertion too.
+        cy.executeGroovy('groovy/setSiteUserName.groovy', {
+            USER_NAME: USER,
+            SITE_KEY: SITE,
+            FIRST_NAME_VALUE: 'Group',
+            LAST_NAME_VALUE: 'Member',
+        }).then((raw) => {
+            if (String(raw ?? '').includes('.failed')) {
+                throw new Error(`setSiteUserName failed: ${raw}`)
+            }
+        })
         cy.executeGroovy('groovy/createSiteGroup.groovy', {
             SITE_KEY: SITE,
             GROUP_NAME: GROUP,

--- a/tests/cypress/fixtures/groovy/addSiteMemberToSiteGroup.groovy
+++ b/tests/cypress/fixtures/groovy/addSiteMemberToSiteGroup.groovy
@@ -1,0 +1,28 @@
+import org.jahia.services.content.JCRCallback
+import org.jahia.services.content.JCRSessionWrapper
+import org.jahia.services.content.JCRTemplate
+import org.jahia.services.usermanager.JahiaGroupManagerService
+import org.jahia.services.usermanager.JahiaUserManagerService
+import javax.jcr.RepositoryException
+
+// Add a SITE-scoped user (MEMBER_NAME, under /sites/<SITE_KEY>/users) as a member of a SITE-scoped
+// group (/sites/<SITE_KEY>/groups/<GROUP_NAME>). Unlike addMemberToGroup.groovy — which looks up its
+// member with no site key and so only resolves server-GLOBAL users (/users) — this one passes
+// SITE_KEY to both lookups, which a site-scoped user needs to resolve at all. Idempotent. Tokens
+// replaced by cy.executeGroovy.
+JCRTemplate.getInstance().doExecuteWithSystemSession(new JCRCallback() {
+    @Override
+    Object doInJCR(JCRSessionWrapper session) throws RepositoryException {
+        JahiaGroupManagerService gms = JahiaGroupManagerService.getInstance()
+        JahiaUserManagerService ums = JahiaUserManagerService.getInstance()
+        def grp = gms.lookupGroup("SITE_KEY", "GROUP_NAME", session)
+        def member = ums.lookupUser("MEMBER_NAME", "SITE_KEY", session)
+        if (grp != null && member != null && !grp.isMember(member)) {
+            grp.addMember(member)
+            session.save()
+        }
+        log.info("addSiteMemberToSiteGroup: MEMBER_NAME -> " + (grp != null ? grp.getPath() : "GROUP_NAME") +
+                " (member found=" + (member != null) + ")")
+        return null
+    }
+})

--- a/tests/cypress/fixtures/groovy/setSiteUserName.groovy
+++ b/tests/cypress/fixtures/groovy/setSiteUserName.groovy
@@ -1,0 +1,22 @@
+import org.jahia.services.content.JCRCallback
+import org.jahia.services.content.JCRSessionWrapper
+import org.jahia.services.content.JCRTemplate
+import org.jahia.services.usermanager.JahiaUserManagerService
+import javax.jcr.RepositoryException
+
+// Set j:firstName/j:lastName on an existing SITE user (looked up the same way
+// createSiteUserWithTitle.groovy creates it). Idempotent. Tokens replaced by cy.executeGroovy.
+JCRTemplate.getInstance().doExecuteWithSystemSession(new JCRCallback() {
+    @Override
+    Object doInJCR(JCRSessionWrapper session) throws RepositoryException {
+        JahiaUserManagerService ums = JahiaUserManagerService.getInstance()
+        def node = ums.lookupUser("USER_NAME", "SITE_KEY", session)
+        if (node != null) {
+            node.setProperty("j:firstName", "FIRST_NAME_VALUE")
+            node.setProperty("j:lastName", "LAST_NAME_VALUE")
+            session.save()
+        }
+        log.info("setSiteUserName: " + (node != null ? node.getPath() : "USER_NAME not found under SITE_KEY"))
+        return null
+    }
+})


### PR DESCRIPTION
## Summary

Tests for https://github.com/Jahia/siteSettings/pull/231: Add end-to-end coverage asserting that a group member's display name renders as literal, escaped
text in Server Settings → Manage Groups, matching the existing coverage for Manage Users and page
models.

## Change

- New Cypress spec `manageGroupsDisplayEscaping.test.cy.ts`: creates a site-scoped user and group,
  adds the user as a member, and asserts the members list renders the member's display name as
  escaped text — structural sibling of `manageUsersDisplayEscaping.test.cy.ts`.
- New Groovy fixture `addSiteMemberToSiteGroup.groovy`: resolves both the group and the member
  within a given site. The existing `addMemberToGroup.groovy` fixture resolves its member with no
  site key, so it only applies to server-global members.
- The spec asserts against the `settingsBootstrap3GoogleMaterialStyle` view (visible in the webflow
  execution URL), pinning coverage to the view variant this admin route renders.

## Verification

Ran the new spec against the current module build: the members list renders the member's display
name as literal text, with no live DOM element created and no script executing.
