### PR TITLE
fix: consistently escape the page-model path in the Page Models admin views

### DIFF
--- a/src/main/resources/jnt_siteSettingsManagePageModels/html/siteSettingsManagePageModels.jsp
+++ b/src/main/resources/jnt_siteSettingsManagePageModels/html/siteSettingsManagePageModels.jsp
@@ -51,7 +51,7 @@
         <tr class="${status.index % 2 == 0 ? 'evenLine' : 'oddLine'}">
             <td>
                 <div class="jahia-template-gxt" jahiatype="module" id="module${pageModel.identifier}" type="existingNode"
-                     scriptInfo="" path="${pageModel.path}" template="hidden.system" dragdrop="false">
+                     scriptInfo="" path="${fn:escapeXml(pageModel.path)}" template="hidden.system" dragdrop="false">
                     <table class="table table-bordered">
                         <tr>
                             <td>${pageModel.displayableName}</td>
@@ -60,9 +60,9 @@
                 </div>
             </td>
             <td>
-                <a href="<c:url value='${url.base}${pageModel.path}.html'/>">${pageModel.properties["j:pageTemplateTitle"].string}</a>
+                <a href="<c:url value='${url.base}${fn:escapeXml(pageModel.path)}.html'/>">${pageModel.properties["j:pageTemplateTitle"].string}</a>
             </td>
-            <td>  <a href="<c:url value='${url.base}${pageModel.path}.html'/>">${pageModel.path}</a></td>
+            <td>  <a href="<c:url value='${url.base}${fn:escapeXml(pageModel.path)}.html'/>">${pageModel.path}</a></td>
 
         </tr>
         <c:set var="isEmpty" value="false"/>

--- a/src/main/resources/jnt_siteSettingsManagePageModels/html/siteSettingsManagePageModels.jsp
+++ b/src/main/resources/jnt_siteSettingsManagePageModels/html/siteSettingsManagePageModels.jsp
@@ -48,10 +48,11 @@
     <tbody>
     <c:forEach items="${moduleMap.currentList}" var="pageModel" begin="${moduleMap.begin}" end="${moduleMap.end}"
                varStatus="status">
+        <c:set var="pageModelPathAttr" value="${fn:escapeXml(pageModel.path)}"/>
         <tr class="${status.index % 2 == 0 ? 'evenLine' : 'oddLine'}">
             <td>
                 <div class="jahia-template-gxt" jahiatype="module" id="module${pageModel.identifier}" type="existingNode"
-                     scriptInfo="" path="${fn:escapeXml(pageModel.path)}" template="hidden.system" dragdrop="false">
+                     scriptInfo="" path="${pageModelPathAttr}" template="hidden.system" dragdrop="false">
                     <table class="table table-bordered">
                         <tr>
                             <td>${pageModel.displayableName}</td>
@@ -60,9 +61,9 @@
                 </div>
             </td>
             <td>
-                <a href="<c:url value='${url.base}${fn:escapeXml(pageModel.path)}.html'/>">${pageModel.properties["j:pageTemplateTitle"].string}</a>
+                <a href="<c:url value='${url.base}${pageModelPathAttr}.html'/>">${pageModel.properties["j:pageTemplateTitle"].string}</a>
             </td>
-            <td>  <a href="<c:url value='${url.base}${fn:escapeXml(pageModel.path)}.html'/>">${pageModel.path}</a></td>
+            <td>  <a href="<c:url value='${url.base}${pageModelPathAttr}.html'/>">${pageModel.path}</a></td>
 
         </tr>
         <c:set var="isEmpty" value="false"/>

--- a/src/main/resources/jnt_siteSettingsManagePageModels/html/siteSettingsManagePageModels.settingsBootstrap3GoogleMaterialStyle.jsp
+++ b/src/main/resources/jnt_siteSettingsManagePageModels/html/siteSettingsManagePageModels.settingsBootstrap3GoogleMaterialStyle.jsp
@@ -52,7 +52,7 @@
                 <tr class="${status.index % 2 == 0 ? 'evenLine' : 'oddLine'}">
                     <td>
                         <div class="jahia-template-gxt" jahiatype="module" id="module${pageModel.identifier}" type="existingNode"
-                             scriptInfo="" path="${pageModel.path}" template="hidden.system" dragdrop="false">
+                             scriptInfo="" path="${fn:escapeXml(pageModel.path)}" template="hidden.system" dragdrop="false">
                             <table class="table table-bordered">
                                 <tr>
                                     <td>${pageModel.displayableName}</td>
@@ -61,10 +61,10 @@
                         </div>
                     </td>
                     <td>
-                        <a href="<c:url value='${url.base}${pageModel.path}.html'/>">${pageModel.properties["j:pageTemplateTitle"].string}</a>
+                        <a href="<c:url value='${url.base}${fn:escapeXml(pageModel.path)}.html'/>">${pageModel.properties["j:pageTemplateTitle"].string}</a>
                     </td>
                     <td>
-                        <a href="<c:url value='${url.base}${pageModel.path}.html'/>">${pageModel.path}</a>
+                        <a href="<c:url value='${url.base}${fn:escapeXml(pageModel.path)}.html'/>">${pageModel.path}</a>
                     </td>
                 </tr>
                 <c:set var="isEmpty" value="false"/>

--- a/src/main/resources/jnt_siteSettingsManagePageModels/html/siteSettingsManagePageModels.settingsBootstrap3GoogleMaterialStyle.jsp
+++ b/src/main/resources/jnt_siteSettingsManagePageModels/html/siteSettingsManagePageModels.settingsBootstrap3GoogleMaterialStyle.jsp
@@ -49,10 +49,11 @@
             <tbody>
             <c:forEach items="${moduleMap.currentList}" var="pageModel" begin="${moduleMap.begin}" end="${moduleMap.end}"
                        varStatus="status">
+                <c:set var="pageModelPathAttr" value="${fn:escapeXml(pageModel.path)}"/>
                 <tr class="${status.index % 2 == 0 ? 'evenLine' : 'oddLine'}">
                     <td>
                         <div class="jahia-template-gxt" jahiatype="module" id="module${pageModel.identifier}" type="existingNode"
-                             scriptInfo="" path="${fn:escapeXml(pageModel.path)}" template="hidden.system" dragdrop="false">
+                             scriptInfo="" path="${pageModelPathAttr}" template="hidden.system" dragdrop="false">
                             <table class="table table-bordered">
                                 <tr>
                                     <td>${pageModel.displayableName}</td>
@@ -61,10 +62,10 @@
                         </div>
                     </td>
                     <td>
-                        <a href="<c:url value='${url.base}${fn:escapeXml(pageModel.path)}.html'/>">${pageModel.properties["j:pageTemplateTitle"].string}</a>
+                        <a href="<c:url value='${url.base}${pageModelPathAttr}.html'/>">${pageModel.properties["j:pageTemplateTitle"].string}</a>
                     </td>
                     <td>
-                        <a href="<c:url value='${url.base}${fn:escapeXml(pageModel.path)}.html'/>">${pageModel.path}</a>
+                        <a href="<c:url value='${url.base}${pageModelPathAttr}.html'/>">${pageModel.path}</a>
                     </td>
                 </tr>
                 <c:set var="isEmpty" value="false"/>


### PR DESCRIPTION
Backport #243 onto https://github.com/Jahia/siteSettings/tree/8_7_x

Bottom of a stack with #245: this PR escapes the page-model path in its **attribute** positions (the `<div>` `path=` and the two `<c:url>` `href=`); the sibling #245, stacked on top, escapes the adjacent **text** values (display name, template title, path link). Both target `8_7_x` under milestone `siteSettings 8.7.1` and are released together — no 8.7.x build is cut between them.

_Tests are not backported: this maintenance line has no `tests/` Cypress harness (none existed at 8.7.0), so the dev-line regression spec has no counterpart here._

_The Static Analysis check is red on a pre-existing `audit-ci`/Node tooling issue on this maintenance branch, unrelated to this change (the diff is JSP-only)._
