### PR TITLE
fix: consistently escape special characters in page model names (Page Models admin)

### DIFF
--- a/src/main/resources/jnt_siteSettingsManagePageModels/html/siteSettingsManagePageModels.jsp
+++ b/src/main/resources/jnt_siteSettingsManagePageModels/html/siteSettingsManagePageModels.jsp
@@ -55,15 +55,15 @@
                      scriptInfo="" path="${pageModelPathAttr}" template="hidden.system" dragdrop="false">
                     <table class="table table-bordered">
                         <tr>
-                            <td>${pageModel.displayableName}</td>
+                            <td>${fn:escapeXml(pageModel.displayableName)}</td>
                         </tr>
                     </table>
                 </div>
             </td>
             <td>
-                <a href="<c:url value='${url.base}${pageModelPathAttr}.html'/>">${pageModel.properties["j:pageTemplateTitle"].string}</a>
+                <a href="<c:url value='${url.base}${pageModelPathAttr}.html'/>"><c:out value='${pageModel.properties["j:pageTemplateTitle"].string}'/></a>
             </td>
-            <td>  <a href="<c:url value='${url.base}${pageModelPathAttr}.html'/>">${pageModel.path}</a></td>
+            <td>  <a href="<c:url value='${url.base}${pageModelPathAttr}.html'/>"><c:out value='${pageModel.path}'/></a></td>
 
         </tr>
         <c:set var="isEmpty" value="false"/>

--- a/src/main/resources/jnt_siteSettingsManagePageModels/html/siteSettingsManagePageModels.settingsBootstrap3GoogleMaterialStyle.jsp
+++ b/src/main/resources/jnt_siteSettingsManagePageModels/html/siteSettingsManagePageModels.settingsBootstrap3GoogleMaterialStyle.jsp
@@ -56,16 +56,16 @@
                              scriptInfo="" path="${pageModelPathAttr}" template="hidden.system" dragdrop="false">
                             <table class="table table-bordered">
                                 <tr>
-                                    <td>${pageModel.displayableName}</td>
+                                    <td>${fn:escapeXml(pageModel.displayableName)}</td>
                                 </tr>
                             </table>
                         </div>
                     </td>
                     <td>
-                        <a href="<c:url value='${url.base}${pageModelPathAttr}.html'/>">${pageModel.properties["j:pageTemplateTitle"].string}</a>
+                        <a href="<c:url value='${url.base}${pageModelPathAttr}.html'/>"><c:out value='${pageModel.properties["j:pageTemplateTitle"].string}'/></a>
                     </td>
                     <td>
-                        <a href="<c:url value='${url.base}${pageModelPathAttr}.html'/>">${pageModel.path}</a>
+                        <a href="<c:url value='${url.base}${pageModelPathAttr}.html'/>"><c:out value='${pageModel.path}'/></a>
                     </td>
                 </tr>
                 <c:set var="isEmpty" value="false"/>


### PR DESCRIPTION
Backport #223 + #235 onto https://github.com/Jahia/siteSettings/tree/8_7_x

~:warning: Depends on #244 — stacked on it to avoid a conflict on the shared anchor lines; merge #244 first (this PR then retargets to `8_7_x` automatically).~

_Tests are not backported: this maintenance line has no `tests/` Cypress harness (none existed at 8.7.0), so the dev-line regression spec has no counterpart here._

_The Static Analysis check is red on a pre-existing `audit-ci`/Node tooling issue on this maintenance branch, unrelated to this change (the diff is JSP-only)._
