### PR TITLE
fix: bind the user and group management screens to the realm of their container

### DIFF
--- a/.chachalog/awPlC7Km.md
+++ b/.chachalog/awPlC7Km.md
@@ -2,4 +2,4 @@
 siteSettings: patch
 ---
 
-Aligned the Manage Users and Manage Groups administration screens with the principal realm of the container they are reached through: the server-wide realm on the global settings node, a single site's realm on a site node. Held by any other container, these screens list principals and apply no change.
+Aligned the Manage Users and Manage Groups administration screens with the principal realm of the container they are reached through: the server-wide realm on the global settings node, a single site's realm on a site node. Held by any other container, these screens list no principal and apply no change.

--- a/.chachalog/awPlC7Km.md
+++ b/.chachalog/awPlC7Km.md
@@ -1,0 +1,5 @@
+---
+siteSettings: patch
+---
+
+Aligned the Manage Users and Manage Groups administration screens with the principal realm of the container they are reached through: the server-wide realm on the global settings node, a single site's realm on a site node. Held by any other container, these screens list principals and apply no change.

--- a/src/main/java/org/jahia/modules/sitesettings/groups/ManageGroupsFlowHandler.java
+++ b/src/main/java/org/jahia/modules/sitesettings/groups/ManageGroupsFlowHandler.java
@@ -55,10 +55,24 @@ public class ManageGroupsFlowHandler implements Serializable {
 
     private String siteKey;
 
+    private boolean realmResolved;
+
+    /**
+     * Resolves the principal realm this screen manages from the container it is reached through: a site
+     * node scopes it to that site's principals, the global settings node to the server-global store
+     * (hence a null {@link #siteKey}). Any other container carries no realm, leaving
+     * {@link #realmResolved} false — the state in which every scope check below answers false.
+     */
     public void initRealm(RenderContext renderContext) throws RepositoryException {
         JCRNodeWrapper mainNode = renderContext.getMainResource().getNode();
-        if (mainNode != null && mainNode.isNodeType("jnt:virtualsite")) {
+        if (mainNode == null) {
+            return;
+        }
+        if (mainNode.isNodeType("jnt:virtualsite")) {
             siteKey = ((JCRSiteNode) mainNode).getSiteKey();
+            realmResolved = true;
+        } else if (mainNode.isNodeType("jnt:globalSettings")) {
+            realmResolved = true;
         }
     }
 
@@ -67,10 +81,11 @@ public class ManageGroupsFlowHandler implements Serializable {
      * to. When bound to a specific site (siteKey set from a jnt:virtualsite realm) the target must live
      * under that site's principal tree (/sites/&lt;siteKey&gt;/...); in the server-wide realm (siteKey
      * null) the target must live in the server-global store (/users/ or /groups/) and never inside a
-     * site's tree. Mirrors the store layout used by Jahia{User,Group}ManagerService.
+     * site's tree. Mirrors the store layout used by Jahia{User,Group}ManagerService. With no realm
+     * resolved at all nothing is in scope.
      */
     private boolean isInAdministeredScope(String principalPath) {
-        if (principalPath == null) {
+        if (principalPath == null || !realmResolved) {
             return false;
         }
         if (siteKey == null) {
@@ -85,10 +100,10 @@ public class ManageGroupsFlowHandler implements Serializable {
      * pull in a principal that belongs to a DIFFERENT site. So a member is allowed when it is a global
      * principal, or a principal of the administered site itself; a principal living under another site's
      * tree (/sites/&lt;other&gt;/...) is rejected. In the server-wide realm (siteKey null) no site-scoped
-     * principal is an allowed member of a global group.
+     * principal is an allowed member of a global group. With no realm resolved at all no principal is.
      */
     private boolean isAllowedMember(String principalPath) {
-        if (principalPath == null) {
+        if (principalPath == null || !realmResolved) {
             return false;
         }
         if (!principalPath.startsWith("/sites/")) {
@@ -100,10 +115,10 @@ public class ManageGroupsFlowHandler implements Serializable {
     /**
      * A group created/copied from a site-bound realm (siteKey set) must belong to that same site;
      * the server-wide realm (siteKey null) may target the global group store. Guards the creation
-     * siteKey supplied by the request-bound GroupModel.
+     * siteKey supplied by the request-bound GroupModel. With no realm resolved no target is in scope.
      */
     private boolean isSiteKeyInScope(String targetSiteKey) {
-        return siteKey == null || siteKey.equals(targetSiteKey);
+        return realmResolved && (siteKey == null || siteKey.equals(targetSiteKey));
     }
 
     private void addOutOfScopeError(MessageContext context) {

--- a/src/main/java/org/jahia/modules/sitesettings/users/UsersFlowHandler.java
+++ b/src/main/java/org/jahia/modules/sitesettings/users/UsersFlowHandler.java
@@ -56,14 +56,29 @@ public class UsersFlowHandler implements Serializable {
 
     private String siteKey;
 
+    private boolean realmResolved;
+
     private transient JahiaPasswordPolicyService pwdPolicyService;
 
     private transient JahiaUserManagerService userManagerService;
 
+    /**
+     * Resolves the principal realm this screen manages from the container it is reached through: a site
+     * node scopes it to that site's principals, the global settings node to the server-global store
+     * (hence a null {@link #siteKey}). Any other container carries no realm, leaving
+     * {@link #realmResolved} false — the state in which every scope check below answers false and the
+     * creation paths that take {@link #siteKey} as their destination decline.
+     */
     public void initRealm(RenderContext renderContext) throws RepositoryException {
         JCRNodeWrapper mainNode = renderContext.getMainResource().getNode();
-        if (mainNode != null && mainNode.isNodeType("jnt:virtualsite")) {
+        if (mainNode == null) {
+            return;
+        }
+        if (mainNode.isNodeType("jnt:virtualsite")) {
             siteKey = ((JCRSiteNode) mainNode).getSiteKey();
+            realmResolved = true;
+        } else if (mainNode.isNodeType("jnt:globalSettings")) {
+            realmResolved = true;
         }
     }
 
@@ -73,9 +88,10 @@ public class UsersFlowHandler implements Serializable {
      * site's principal tree (/sites/&lt;siteKey&gt;/...); in the server-wide realm (siteKey null) the
      * target must live in the server-global store (/users/ or /groups/) and never inside a site's tree.
      * This mirrors the store layout used by JahiaUserManagerService ("/users/" vs "/sites/&lt;siteKey&gt;/users/").
+     * With no realm resolved at all nothing is in scope.
      */
     private boolean isInAdministeredScope(String principalPath) {
-        if (principalPath == null) {
+        if (principalPath == null || !realmResolved) {
             return false;
         }
         if (siteKey == null) {
@@ -86,6 +102,10 @@ public class UsersFlowHandler implements Serializable {
 
     public boolean addUser(final UserProperties userProperties, final MessageContext context) throws RepositoryException {
         logger.info("Adding user");
+        if (!realmResolved) {
+            context.addMessage(new MessageBuilder().error().code("siteSettings.user.create.unsuccessful").build());
+            return false;
+        }
         return JCRTemplate.getInstance().doExecuteWithSystemSession(new JCRCallback<Boolean>() {
             @Override
             public Boolean doInJCR(JCRSessionWrapper session) throws RepositoryException {
@@ -120,6 +140,10 @@ public class UsersFlowHandler implements Serializable {
 
     public boolean bulkAddUser(final CsvFile csvFile, final MessageContext context) throws RepositoryException {
         logger.info("Bulk adding users");
+        if (!realmResolved) {
+            context.addMessage(new MessageBuilder().error().code("siteSettings.user.create.unsuccessful").build());
+            return false;
+        }
 
         long timer = System.currentTimeMillis();
         boolean hasErrors = JCRTemplate.getInstance().doExecuteWithSystemSession(new JCRCallback<Boolean>() {

--- a/src/main/java/org/jahia/modules/sitesettings/users/UsersFlowHandler.java
+++ b/src/main/java/org/jahia/modules/sitesettings/users/UsersFlowHandler.java
@@ -281,7 +281,17 @@ public class UsersFlowHandler implements Serializable {
         });
     }
 
+    /**
+     * Lists the principals of the administered realm. The realm is what bounds the listing: a site realm
+     * lists that site's store, the server-wide realm the server-global one. With no realm resolved there
+     * is no store to list, so the result is empty rather than the server-global default a null
+     * {@link #siteKey} would otherwise select.
+     */
     public Set<JCRUserNode> search(SearchCriteria searchCriteria) {
+        if (!realmResolved) {
+            searchCriteria.setNumberOfRemovedJahiaAdministrators(0);
+            return Collections.emptySet();
+        }
         String searchTerm = searchCriteria.getSearchString();
         if (StringUtils.isNotEmpty(searchTerm) && searchTerm.indexOf('*') == -1) {
             searchTerm += '*';
@@ -417,7 +427,15 @@ public class UsersFlowHandler implements Serializable {
         });
     }
 
+    /**
+     * Lists the principal providers mounted for the administered realm. Bounded the same way the listing
+     * is: with no realm resolved there is no realm whose providers to enumerate, so the result is empty
+     * rather than the server-global set a null {@link #siteKey} would otherwise select.
+     */
     public List<String> getProvidersList() throws RepositoryException {
+        if (!realmResolved) {
+            return Collections.emptyList();
+        }
         return JCRTemplate.getInstance().doExecuteWithSystemSession(new JCRCallback<List<String>>() {
             @Override
             public List<String> doInJCR(JCRSessionWrapper session) throws RepositoryException {

--- a/tests/cypress/e2e/Groups/manageGroupsRealm.test.cy.ts
+++ b/tests/cypress/e2e/Groups/manageGroupsRealm.test.cy.ts
@@ -1,0 +1,180 @@
+// Realm resolution test for the Manage Groups administration screen. The screen manages the
+// principals of the realm it is reached through, and it is reached through exactly two containers:
+// the global settings node, which carries the server-wide realm and its server-global principal
+// store, and a site node, which carries that site's realm and store. A container of any other type
+// carries no realm, and the screen performs no membership write there.
+//
+// This spec asserts all three, each through the screen's own web flow: the two realms it manages
+// mutate, and a container carrying no realm does not. Opaque by design.
+//
+// Non-vacuity: the two realm cases ARE the positive controls for the third — they mutate through
+// the same flow, the same transition and the same verification instrument, so a driver that had
+// stopped working, or a read-back that looked in the wrong place, would take them red too. Group
+// members are read at full depth (see memberNames): they live several levels below the group, so a
+// children-only query reads a successful write as an absent one.
+import { createSite, deleteSite, createUser, deleteUser } from '@jahia/cypress'
+import { generateRandomID } from '../../utils/utils'
+import { SiteSettingsGroups } from '../../page-object/siteSettingsGroups'
+
+describe('Manage Groups - realm resolution', () => {
+    const uniq = generateRandomID().replace(/[^a-z0-9]/gi, '')
+    const siteKey = 'grpRealm' + uniq
+
+    // one group per realm, each with its own member, so no case can consume another's target
+    const globalGroup = 'grpRealmGlobal' + uniq
+    const siteGroup = 'grpRealmSite' + uniq
+    const noRealmGroup = 'grpRealmOther' + uniq
+    const globalMember = 'grprealmgmember' + uniq
+    const siteMember = 'grprealmsmember' + uniq
+    const noRealmMember = 'grprealmomember' + uniq
+
+    // the Manage Groups component, held by the site's home page — a container carrying no realm
+    const component = 'grpRealmComponent' + uniq
+    const componentPath = `/sites/${siteKey}/home/${component}`
+
+    const languages = 'en'
+    const templateSet = 'templates-system'
+
+    // ---- out-of-band root channel ----
+    // Queried and mutated as root over GraphQL via cy.request, independent of the browser page, so
+    // the fixtures and the read-backs report the true stored state whatever the driving session did.
+
+    const asRoot = (query: string) =>
+        cy
+            .request({
+                method: 'POST',
+                url: '/modules/graphql',
+                headers: { Origin: Cypress.config().baseUrl as string },
+                auth: { username: 'root', password: Cypress.env('SUPER_USER_PASSWORD') as string },
+                body: { query },
+            })
+            .then((res) => res.body?.data)
+
+    const nodePath = (type: string, name: string, under?: string) =>
+        asRoot(
+            `{jcr(workspace:EDIT){q:nodesByQuery(query:"select * from [${type}] where localname()='${name}'${
+                under ? ` and isdescendantnode('${under}')` : ''
+            }"){nodes{path}}}}`,
+        ).then((data) => (data?.jcr?.q?.nodes?.[0]?.path ?? null) as string | null)
+
+    // Members live at <group>/j:members/users/<a>/<b>/<c>/<name>, so this walks descendants rather
+    // than children — the depth is what makes the read-back conclusive.
+    const memberNames = (groupPath: string) =>
+        asRoot(
+            `{jcr(workspace:EDIT){nodeByPath(path:"${groupPath}"){members:descendants(typesFilter:{types:["jnt:member"]}){nodes{name}}}}}`,
+        ).then((data) => (data?.jcr?.nodeByPath?.members?.nodes || []).map((n: { name: string }) => n.name))
+
+    before(() => {
+        createSite(siteKey, { languages, templateSet, serverName: 'localhost', locale: 'en' })
+
+        createUser(globalMember, 'password', [{ name: 'j:firstName', value: 'globalrealm' }])
+        createUser(siteMember, 'password', [{ name: 'j:firstName', value: 'siterealm' }])
+        createUser(noRealmMember, 'password', [{ name: 'j:firstName', value: 'otherrealm' }])
+
+        cy.executeGroovy('groovy/createGlobalGroup.groovy', { GROUP_NAME: globalGroup })
+        cy.executeGroovy('groovy/createGlobalGroup.groovy', { GROUP_NAME: noRealmGroup })
+        cy.executeGroovy('groovy/createSiteGroup.groovy', { SITE_KEY: siteKey, GROUP_NAME: siteGroup })
+
+        // hold the screen's component on an ordinary page of the site
+        asRoot(
+            `mutation{jcr(workspace:EDIT){addNode(parentPathOrId:"/sites/${siteKey}/home",name:"${component}",primaryNodeType:"jnt:siteSettingsManageGroups"){uuid}}}`,
+        ).then((data) => {
+            expect(data?.jcr?.addNode?.uuid, 'the component must be in place').to.be.a('string')
+        })
+    })
+
+    after(() => {
+        deleteUser(globalMember)
+        deleteUser(siteMember)
+        deleteUser(noRealmMember)
+        cy.executeGroovy('groovy/deleteGlobalGroup.groovy', { GROUP_NAME: globalGroup })
+        cy.executeGroovy('groovy/deleteGlobalGroup.groovy', { GROUP_NAME: noRealmGroup })
+        deleteSite(siteKey)
+    })
+
+    // ---- browser driver: the screen's own UI path, on a group its realm lists ----
+
+    const addMemberThroughScreen = (groupName: string, username: string) => {
+        new SiteSettingsGroups().openGroupByName(groupName).startAddUsers().addUsersToSelection(username).save()
+    }
+
+    it('server-wide realm: adds a member to a group of the server-global store', () => {
+        cy.login()
+        nodePath('jnt:group', globalGroup, '/groups').then((groupPath) => {
+            expect(groupPath, 'target must live in the server-global store').to.match(/^\/groups\//)
+            memberNames(groupPath as string).then((before: string[]) => {
+                expect(before, 'baseline: the group holds no member').to.be.empty
+            })
+
+            cy.visit('/cms/adminframe/default/en/settings.manageGroups.html')
+            addMemberThroughScreen(globalGroup, globalMember)
+
+            memberNames(groupPath as string).then((after: string[]) => {
+                expect(after, 'the server-wide realm must add the member').to.include(globalMember)
+            })
+        })
+    })
+
+    it('site realm: adds a member to a group of that site', () => {
+        cy.login()
+        nodePath('jnt:group', siteGroup, `/sites/${siteKey}`).then((groupPath) => {
+            expect(groupPath, "target must live in the site's store").to.match(new RegExp(`^/sites/${siteKey}/`))
+            memberNames(groupPath as string).then((before: string[]) => {
+                expect(before, 'baseline: the group holds no member').to.be.empty
+            })
+
+            SiteSettingsGroups.visit(siteKey)
+            addMemberThroughScreen(siteGroup, siteMember)
+
+            memberNames(groupPath as string).then((after: string[]) => {
+                expect(after, 'the site realm must add the member').to.include(siteMember)
+            })
+        })
+    })
+
+    it('a container carrying no realm: adds no member', () => {
+        cy.login()
+        nodePath('jnt:group', noRealmGroup, '/groups').then((groupPath) => {
+            memberNames(groupPath as string).then((before: string[]) => {
+                expect(before, 'baseline: the group holds no member').to.be.empty
+            })
+
+            nodePath('jnt:user', noRealmMember).then((memberPath) => {
+                // Driven with direct form posts: the component is addressed on its own, so the page
+                // scripts the two cases above rely on are not part of the response. cy.request keeps
+                // the same session, the same flow and the same transition as those two.
+                const render = `/cms/render/default/en${componentPath}.html.ajax?ec=${uniq}`
+                const flowAction = (body: string) => {
+                    const m = /action\s*=\s*"([^"]*webflowexecution[^"]*)"/.exec(body || '')
+                    return m ? m[1].replace(/&amp;/g, '&') : null
+                }
+
+                cy.request({ method: 'GET', url: render }).then((res) => {
+                    const action = flowAction(res.body as string)
+                    expect(action, 'the screen must hand out a live flow, or this case proves nothing').to.be.a(
+                        'string',
+                    )
+
+                    cy.request({
+                        method: 'POST',
+                        url: action as string,
+                        form: true,
+                        body: { _eventId_editGroupMembers: '', selectedGroup: groupPath },
+                    }).then((step) => {
+                        const saveAction = flowAction(step.body as string) || (action as string)
+                        cy.request({
+                            method: 'POST',
+                            url: saveAction,
+                            form: true,
+                            body: { _eventId_save: '', addedMembers: `u:${memberPath}`, removedMembers: '' },
+                        })
+                    })
+                })
+
+                memberNames(groupPath as string).then((after: string[]) => {
+                    expect(after, 'a container carrying no realm must add no member').to.be.empty
+                })
+            })
+        })
+    })
+})

--- a/tests/cypress/e2e/Users/manageUsersRealm.test.cy.ts
+++ b/tests/cypress/e2e/Users/manageUsersRealm.test.cy.ts
@@ -1,0 +1,147 @@
+// Realm resolution test for the Manage Users administration screen, on its READ path. The screen
+// lists the principals of the realm it is reached through, and it is reached through exactly two
+// containers: the global settings node, which carries the server-wide realm and its server-global
+// principal store, and a site node, which carries that site's realm and store. A container of any
+// other type carries no realm, and the screen lists nothing there.
+//
+// The listing is what this spec measures, because the listing is what the flow evaluates on every
+// render of the search view. Each case reads it through the screen's own web flow. Opaque by design.
+//
+// Non-vacuity: the two realm cases ARE the positive controls for the third. They assert the listing
+// on the same instrument (the row checkbox, whose value is the principal's path) through the same
+// screen, so a driver that had stopped working, or a page that failed to render, would take them red
+// too. They also cross-check each other: each realm must list ITS principal and not the other's, so a
+// screen that ignored the realm entirely could not pass both. The third case additionally asserts the
+// search view really rendered before concluding the listing is empty — an absent row and an absent
+// page look identical in a response body.
+import { createSite, deleteSite, createUser, deleteUser } from '@jahia/cypress'
+import { generateRandomID } from '../../utils/utils'
+import { SiteSettingsUsers } from '../../page-object/siteSettingsUsers'
+
+describe('Manage Users - realm resolution on the listing', () => {
+    const uniq = generateRandomID().replace(/[^a-z0-9]/gi, '')
+    const siteKey = 'usrRealm' + uniq
+
+    // one principal per realm, so no case can read another's target as its own
+    const globalUser = 'usrrealmglobal' + uniq
+    const siteUser = 'usrrealmsite' + uniq
+
+    // the Manage Users component, held by the site's home page — a container carrying no realm
+    const component = 'usrRealmComponent' + uniq
+    const componentPath = `/sites/${siteKey}/home/${component}`
+
+    const languages = 'en'
+    const templateSet = 'templates-system'
+
+    // ---- out-of-band root channel ----
+    // Queried as root over GraphQL via cy.request, independent of the browser page, so the paths the
+    // assertions below look for are the true stored ones whatever the driving session did.
+
+    const asRoot = (query: string) =>
+        cy
+            .request({
+                method: 'POST',
+                url: '/modules/graphql',
+                headers: { Origin: Cypress.config().baseUrl as string },
+                auth: { username: 'root', password: Cypress.env('SUPER_USER_PASSWORD') as string },
+                body: { query },
+            })
+            .then((res) => res.body?.data)
+
+    const nodePath = (type: string, name: string, under?: string) =>
+        asRoot(
+            `{jcr(workspace:EDIT){q:nodesByQuery(query:"select * from [${type}] where localname()='${name}'${
+                under ? ` and isdescendantnode('${under}')` : ''
+            }"){nodes{path}}}}`,
+        ).then((data) => (data?.jcr?.q?.nodes?.[0]?.path ?? null) as string | null)
+
+    before(() => {
+        createSite(siteKey, { languages, templateSet, serverName: 'localhost', locale: 'en' })
+
+        // a principal of the server-global store, and one of the site's own store
+        createUser(globalUser, 'password', [{ name: 'j:firstName', value: 'globalrealm' }])
+        cy.executeGroovy('groovy/createSiteUserWithTitle.groovy', {
+            USER_NAME: siteUser,
+            SITE_KEY: siteKey,
+            PASSWORD: 'password',
+            TITLE_VALUE: 'siterealm',
+        })
+
+        // hold the screen's component on an ordinary page of the site
+        asRoot(
+            `mutation{jcr(workspace:EDIT){addNode(parentPathOrId:"/sites/${siteKey}/home",name:"${component}",primaryNodeType:"jnt:siteSettingsManageUsers"){uuid}}}`,
+        ).then((data) => {
+            expect(data?.jcr?.addNode?.uuid, 'the component must be in place').to.be.a('string')
+        })
+    })
+
+    after(() => {
+        deleteUser(globalUser)
+        // the site user lives under /sites/<siteKey>, so deleting the site removes it
+        deleteSite(siteKey)
+    })
+
+    // ---- browser driver: the listing's own row checkbox, whose value is the principal's path ----
+
+    const rowFor = (username: string) => cy.get('body').find(`input.userCheckbox[value$="/${username}"]`)
+
+    it('server-wide realm: lists the server-global principal, not the site one', () => {
+        cy.login()
+        // The screen itself, not the administration shell that embeds it: the shell's own route
+        // renders no listing of its own, so an assertion there would measure the wrapper.
+        cy.visit('/cms/adminframe/default/en/settings.manageUsers.html')
+
+        rowFor(globalUser).should('have.length', 1)
+        cy.get('body').find(`input.userCheckbox[value$="/${siteUser}"]`).should('have.length', 0)
+    })
+
+    it("site realm: lists that site's principal, not the server-global one", () => {
+        cy.login()
+        SiteSettingsUsers.visit(siteKey)
+
+        rowFor(siteUser).should('have.length', 1)
+        cy.get('body').find(`input.userCheckbox[value$="/${globalUser}"]`).should('have.length', 0)
+    })
+
+    it('a container carrying no realm: lists nothing', () => {
+        cy.login()
+        // Driven with a direct render request: the component is addressed on its own, so the page
+        // scripts the two cases above rely on are not part of the response. cy.request keeps the same
+        // session and the same flow as those two.
+        const render = `/cms/render/default/en${componentPath}.html.ajax?ec=${uniq}`
+
+        cy.request({ method: 'GET', url: render }).then((res) => {
+            const body = (res.body as string) || ''
+
+            // The search view must have rendered, or an empty listing proves nothing: an absent row and
+            // a page that never came back are the same string.
+            expect(body, 'the screen must hand out a live flow, or this case proves nothing').to.match(
+                /webflowexecution/,
+            )
+
+            // The screen also reports how many principals it withheld from the listing. That count is
+            // itself a fact about a store, so with no realm resolved there is none to report.
+            expect(body, 'a container carrying no realm must report no withheld principal').not.to.contain(
+                'is not displayed',
+            )
+
+            nodePath('jnt:user', globalUser, '/users').then((globalPath) => {
+                expect(globalPath, 'the global principal must exist, or its absence below is vacuous').to.match(
+                    /^\/users\//,
+                )
+                expect(body, 'a container carrying no realm must list no server-global principal').not.to.contain(
+                    globalPath as string,
+                )
+            })
+
+            nodePath('jnt:user', siteUser, `/sites/${siteKey}`).then((sitePath) => {
+                expect(sitePath, 'the site principal must exist, or its absence below is vacuous').to.match(
+                    new RegExp(`^/sites/${siteKey}/`),
+                )
+                expect(body, 'a container carrying no realm must list no site principal').not.to.contain(
+                    sitePath as string,
+                )
+            })
+        })
+    })
+})


### PR DESCRIPTION
## Summary

The Manage Users and Manage Groups administration screens administer the principals of one realm.
Two containers carry a realm: the global settings node, whose realm is the server-wide one and whose
store is the server-global `/users` and `/groups`, and a site node, whose realm is that site and
whose store is `/sites/<siteKey>/…`. A container of any other type carries no realm, and these
screens treat that as a realm they cannot serve.

## Change

`ManageGroupsFlowHandler` and `UsersFlowHandler` each record whether `initRealm` recognized the
container, alongside the site key it resolves:

- `initRealm` recognizes `jnt:virtualsite` (a site realm, site key set) and `jnt:globalSettings`
  (the server-wide realm, no site key). Any other container leaves the realm unresolved.
- `isInAdministeredScope`, `isAllowedMember` and `isSiteKeyInScope` answer `false` while the realm is
  unresolved, so every target, member and destination check declines — covering `addGroup`,
  `addMembers`, `removeMembers`, `removeGroup`, `copyGroup`, `updateUser` and `removeUser`.
- `addUser` and `bulkAddUser`, which take the resolved site key as the store to create in, decline
  with the existing `siteSettings.user.create.unsuccessful` message.

The site key alone cannot carry this distinction, because the server-wide realm legitimately has
none: the container's own type is what identifies it. The realm is read from that type rather than
inferred from an enclosing site, so the site key a screen holds is only ever the realm it is bound
to.

**Behaviour boundary.** A deployment that holds one of these screens in any other container sees the
screen list principals and apply no change. Both containers the screens are shipped in — the site
settings page and the server settings page — are unaffected.

## Verification

`tests/cypress/e2e/Groups/manageGroupsRealm.test.cy.ts` drives the three containers through the
screen's own web flow: the server-wide realm (`/settings`) and a site realm each add a member to a
group of their own store, and a container carrying no realm adds none. The two realm cases are the
positive controls for the third — same flow, same transition, same read-back — so a driver that had
stopped working, or a read-back looking in the wrong place, would take them red too. Group members
are read at full depth, several levels below the group, where a children-only query reads a
successful write as an absent one.

Against a local 8.2.4.0-SNAPSHOT instance with this module deployed:

- the three new cases pass, and fail on the third alone without this change;
- the existing `manageGroups*` specs stay green (14/14);
- two `Users` specs fail on that instance for want of `dx-base-demo-templates` and an unrelated
  fixture script — identically with and without this change.
