### PR TITLE
fix: render site settings components only for callers administering the resource

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,24 @@
             </resource>
         </resources>
         <plugins>
+            <!-- DO NOT REMOVE without checking the built jar first.
+                 This line's parent (jahia-modules 8.1.0.0) does not switch on bnd's DS annotation scanning.
+                 Without this instruction an @Component class compiles and ships but produces no OSGI-INF
+                 descriptor and no Service-Component header, so the component never registers or activates —
+                 it fails SILENTLY, which here would mean the settings-component permission filter does not
+                 run at all. Verify OSGI-INF/org.jahia.modules.sitesettings.render.SettingsComponentPermissionFilter.xml
+                 is present in the built jar. Diagnose with Karaf `scr:list`: a component missing entirely,
+                 rather than UNSATISFIED, means the annotations were never scanned. -->
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <_dsannotations>*</_dsannotations>
+                    </instructions>
+                </configuration>
+            </plugin>
             <plugin>
                 <artifactId>maven-clean-plugin</artifactId>
                 <version>3.1.0</version>

--- a/src/main/java/org/jahia/modules/sitesettings/render/SettingsComponentPermissionFilter.java
+++ b/src/main/java/org/jahia/modules/sitesettings/render/SettingsComponentPermissionFilter.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (C) 2002-2022 Jahia Solutions Group SA. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jahia.modules.sitesettings.render;
+
+import org.apache.commons.lang.StringUtils;
+import org.jahia.services.content.JCRNodeWrapper;
+import org.jahia.services.render.RenderContext;
+import org.jahia.services.render.Resource;
+import org.jahia.services.render.filter.AbstractFilter;
+import org.jahia.services.render.filter.RenderChain;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Renders a settings component only when the caller holds an administration permission on the resource the
+ * request is actually made against.
+ * <p>
+ * The permission requirement belongs on the component, not only on the settings template that normally hosts
+ * it ({@code j:requiredPermissionNames}): a component's access rule should travel with the component and hold
+ * on every render path, regardless of where the component is placed. This filter makes the requirement a
+ * property of the component so it applies uniformly. Because {@code WebflowAction} re-enters the render chain
+ * for each webflow POST, it covers every transition too, not just the initial GET.
+ * <p>
+ * The check is evaluated against the <strong>main resource</strong> of the render, not against the component
+ * node, and that is load-bearing rather than incidental: the component node of a legitimate settings screen
+ * lives inside its module ({@code /modules/...}), where a site-scoped administrator holds nothing, while the
+ * main resource is the site (site-settings route) or the global settings node (server-administration route) —
+ * which is what the corresponding administrator role is actually granted on. Checking the component node,
+ * which is the obvious implementation, would refuse real site administrators.
+ * <p>
+ * Either {@code site-admin} or {@code admin} is accepted, since these screens are reached from both the
+ * site-scoped and the server-wide administration route. Both are core permissions
+ * ({@code root-permissions.xml}) granted by the {@code site-administrator} / {@code server-administrator}
+ * roles; the finer per-screen permissions are contributed by this module's own {@code permissions.xml} and
+ * resolve to {@code false} where they are not registered on an instance, which would fail closed for
+ * administrators too. The finer requirement still applies on the administration route via the template, so
+ * this filter is an additional condition and never a replacement. Failing to resolve a main resource yields
+ * an empty fragment rather than a rendered component.
+ * <p>
+ * Registered as a Spring bean, matching how this maintenance line wires its module components; the
+ * development line registers the same filter through OSGi Declarative Services.
+ */
+// equals/hashCode are deliberately NOT overridden for the field below: AbstractFilter defines
+// equality as (concrete class, priority), which is the key RenderService.addFilter uses to replace an
+// already-registered filter. Widening it to the configuration would break that re-registration.
+@SuppressWarnings("java:S2160")
+public class SettingsComponentPermissionFilter extends AbstractFilter {
+
+    private static final Logger logger = LoggerFactory.getLogger(SettingsComponentPermissionFilter.class);
+
+    private String[] requiredPermissions = new String[0];
+    private String requiredPermissionsLabel = "";
+
+    /**
+     * Sets the permissions accepted by this filter, as a comma-separated list. A caller holding any
+     * one of them on the main resource may render the component.
+     *
+     * @param requiredPermissions comma-separated list of permission names
+     */
+    public void setRequiredPermissions(String requiredPermissions) {
+        String[] parsed = StringUtils.split(StringUtils.defaultString(requiredPermissions), ',');
+        for (int i = 0; i < parsed.length; i++) {
+            parsed[i] = parsed[i].trim();
+        }
+        this.requiredPermissions = parsed;
+        this.requiredPermissionsLabel = StringUtils.join(parsed, ", ");
+    }
+
+    @Override
+    public String prepare(RenderContext renderContext, Resource resource, RenderChain chain) throws Exception {
+        if (requiredPermissions.length == 0) {
+            logger.error("No permission configured for {}; refusing to render {}",
+                    getClass().getName(), resource.getNodePath());
+            return StringUtils.EMPTY;
+        }
+
+        Resource mainResource = renderContext.getMainResource();
+        JCRNodeWrapper contextNode = mainResource != null ? mainResource.getNode() : null;
+        if (contextNode == null) {
+            logger.warn("No main resource to evaluate {} against; not rendering it", resource.getNodePath());
+            return StringUtils.EMPTY;
+        }
+
+        for (String permission : requiredPermissions) {
+            if (contextNode.hasPermission(permission)) {
+                return null;
+            }
+        }
+
+        if (logger.isWarnEnabled()) {
+            logger.warn("Not rendering {}: {} holds none of {} on {}", resource.getNodePath(),
+                    renderContext.getUser() != null ? renderContext.getUser().getName() : "the current user",
+                    requiredPermissionsLabel, contextNode.getPath());
+        }
+        return StringUtils.EMPTY;
+    }
+}

--- a/src/main/java/org/jahia/modules/sitesettings/render/SettingsComponentPermissionFilter.java
+++ b/src/main/java/org/jahia/modules/sitesettings/render/SettingsComponentPermissionFilter.java
@@ -1,18 +1,3 @@
-/*
- * Copyright (C) 2002-2022 Jahia Solutions Group SA. All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.jahia.modules.sitesettings.render;
 
 import org.apache.commons.lang.StringUtils;
@@ -21,8 +6,15 @@ import org.jahia.services.render.RenderContext;
 import org.jahia.services.render.Resource;
 import org.jahia.services.render.filter.AbstractFilter;
 import org.jahia.services.render.filter.RenderChain;
+import org.jahia.services.render.filter.RenderFilter;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * Renders a settings component only when the caller holds an administration permission on the resource the
@@ -50,51 +42,56 @@ import org.slf4j.LoggerFactory;
  * this filter is an additional condition and never a replacement. Failing to resolve a main resource yields
  * an empty fragment rather than a rendered component.
  * <p>
- * Registered as a Spring bean, matching how this maintenance line wires its module components; the
- * development line registers the same filter through OSGi Declarative Services.
+ * Registered via OSGi Declarative Services, matching the development line. NOTE: this requires the
+ * {@code <_dsannotations>*</_dsannotations>} bnd instruction added to this module's pom — without it an
+ * {@code @Component} class compiles and ships but emits no {@code OSGI-INF} descriptor, so the component
+ * never registers and this filter silently does not run. Confirm the descriptor is present in the built jar
+ * rather than assuming it.
  */
-// equals/hashCode are deliberately NOT overridden for the field below: AbstractFilter defines
-// equality as (concrete class, priority), which is the key RenderService.addFilter uses to replace an
-// already-registered filter. Widening it to the configuration would break that re-registration.
-@SuppressWarnings("java:S2160")
+@Component(service = RenderFilter.class, immediate = true)
 public class SettingsComponentPermissionFilter extends AbstractFilter {
 
     private static final Logger logger = LoggerFactory.getLogger(SettingsComponentPermissionFilter.class);
 
-    private String[] requiredPermissions = new String[0];
-    private String requiredPermissionsLabel = "";
+    /** Node types gated by this filter — every settings screen this module ships on this line. */
+    private static final String APPLY_ON_NODE_TYPES =
+            "jnt:siteSettingsManageUsers," +
+            "jnt:siteSettingsManageGroups," +
+            "jnt:siteSettingsManageModules," +
+            "jnt:siteSettingsManagePageModels," +
+            "jnt:siteSettingsWcagCompliance," +
+            "jnt:siteSettingsHtmlFiltering," +
+            "jnt:siteSettingsManageLanguages";
 
-    /**
-     * Sets the permissions accepted by this filter, as a comma-separated list. A caller holding any
-     * one of them on the main resource may render the component.
-     *
-     * @param requiredPermissions comma-separated list of permission names
-     */
-    public void setRequiredPermissions(String requiredPermissions) {
-        String[] parsed = StringUtils.split(StringUtils.defaultString(requiredPermissions), ',');
-        for (int i = 0; i < parsed.length; i++) {
-            parsed[i] = parsed[i].trim();
-        }
-        this.requiredPermissions = parsed;
-        this.requiredPermissionsLabel = StringUtils.join(parsed, ", ");
+    /** Any one of these on the main resource is sufficient. */
+    private static final List<String> REQUIRED_PERMISSIONS =
+            Collections.unmodifiableList(Arrays.asList("site-admin", "admin"));
+
+    private static final String REQUIRED_PERMISSIONS_LABEL = StringUtils.join(REQUIRED_PERMISSIONS, ", ");
+
+    @Activate
+    public void activate() {
+        // Priority 22: immediately after core's own permission check (TemplatePermissionCheckFilter, 21) and
+        // before the fragment is produced or cached, so a refusal cannot populate a cache entry that a
+        // differently-privileged caller could later be served.
+        setPriority(22);
+        setApplyOnNodeTypes(APPLY_ON_NODE_TYPES);
+        setDescription("Renders a settings component only for a caller holding an administration permission "
+                + "on the main resource");
+        logger.debug("SettingsComponentPermissionFilter active on {}", APPLY_ON_NODE_TYPES);
     }
 
     @Override
     public String prepare(RenderContext renderContext, Resource resource, RenderChain chain) throws Exception {
-        if (requiredPermissions.length == 0) {
-            logger.error("No permission configured for {}; refusing to render {}",
-                    getClass().getName(), resource.getNodePath());
-            return StringUtils.EMPTY;
-        }
-
         Resource mainResource = renderContext.getMainResource();
         JCRNodeWrapper contextNode = mainResource != null ? mainResource.getNode() : null;
         if (contextNode == null) {
+            // Fail closed: with no main resource there is nothing to evaluate the permission against.
             logger.warn("No main resource to evaluate {} against; not rendering it", resource.getNodePath());
             return StringUtils.EMPTY;
         }
 
-        for (String permission : requiredPermissions) {
+        for (String permission : REQUIRED_PERMISSIONS) {
             if (contextNode.hasPermission(permission)) {
                 return null;
             }
@@ -103,7 +100,7 @@ public class SettingsComponentPermissionFilter extends AbstractFilter {
         if (logger.isWarnEnabled()) {
             logger.warn("Not rendering {}: {} holds none of {} on {}", resource.getNodePath(),
                     renderContext.getUser() != null ? renderContext.getUser().getName() : "the current user",
-                    requiredPermissionsLabel, contextNode.getPath());
+                    REQUIRED_PERMISSIONS_LABEL, contextNode.getPath());
         }
         return StringUtils.EMPTY;
     }

--- a/src/main/java/org/jahia/modules/sitesettings/render/SettingsComponentPermissionFilter.java
+++ b/src/main/java/org/jahia/modules/sitesettings/render/SettingsComponentPermissionFilter.java
@@ -71,10 +71,14 @@ public class SettingsComponentPermissionFilter extends AbstractFilter {
 
     @Activate
     public void activate() {
-        // Priority 22: immediately after core's own permission check (TemplatePermissionCheckFilter, 21) and
-        // before the fragment is produced or cached, so a refusal cannot populate a cache entry that a
-        // differently-privileged caller could later be served.
-        setPriority(22);
+        // Priority 21.5: immediately after core's own permission check (TemplatePermissionCheckFilter, 21) and
+        // clear of the 22.x template band. AbstractFilter breaks a priority tie on the class name, so an exact
+        // 22 would order this against core's templateNodeFilter (22.0) by an accident of package naming rather
+        // than by intent; 21.5 states the intended slot instead of relying on that.
+        // This runs inside the fragment cache's generation scope (live only, 16 / 16.5), which is safe because
+        // that cache keys on the caller's ACL signature: an entry generated for an administrator is not served
+        // to a caller who lacks the grant.
+        setPriority(21.5f);
         setApplyOnNodeTypes(APPLY_ON_NODE_TYPES);
         setDescription("Renders a settings component only for a caller holding an administration permission "
                 + "on the main resource");

--- a/src/main/resources/META-INF/spring/site-settings.xml
+++ b/src/main/resources/META-INF/spring/site-settings.xml
@@ -16,19 +16,4 @@
         <entry key="userDisplayLimit" value="${jahia.settings.userDisplayLimit:100}"/>
         <entry key="memberDisplayLimit" value="${jahia.settings.memberDisplayLimit:100}"/>
     </util:map>
-
-    <!-- The permission requirement belongs on the component, not only on the settings template that
-         normally hosts it: a component's access rule should travel with the component and hold on every
-         render path. Evaluated on the render's main resource, which is the node each administrator role is
-         granted on; either administration permission is accepted, since these screens are reached from both
-         the site-scoped and the server-wide administration route. -->
-    <bean id="settingsComponentPermissionFilter"
-          class="org.jahia.modules.sitesettings.render.SettingsComponentPermissionFilter">
-        <property name="priority" value="22"/>
-        <property name="description"
-                  value="Renders a settings component only for a caller holding an administration permission on the main resource"/>
-        <property name="applyOnNodeTypes"
-                  value="jnt:siteSettingsManageUsers,jnt:siteSettingsManageGroups,jnt:siteSettingsManageModules,jnt:siteSettingsManagePageModels,jnt:siteSettingsWcagCompliance,jnt:siteSettingsHtmlFiltering,jnt:siteSettingsManageLanguages"/>
-        <property name="requiredPermissions" value="site-admin,admin"/>
-    </bean>
 </beans>

--- a/src/main/resources/META-INF/spring/site-settings.xml
+++ b/src/main/resources/META-INF/spring/site-settings.xml
@@ -16,4 +16,19 @@
         <entry key="userDisplayLimit" value="${jahia.settings.userDisplayLimit:100}"/>
         <entry key="memberDisplayLimit" value="${jahia.settings.memberDisplayLimit:100}"/>
     </util:map>
+
+    <!-- The permission requirement belongs on the component, not only on the settings template that
+         normally hosts it: a component's access rule should travel with the component and hold on every
+         render path. Evaluated on the render's main resource, which is the node each administrator role is
+         granted on; either administration permission is accepted, since these screens are reached from both
+         the site-scoped and the server-wide administration route. -->
+    <bean id="settingsComponentPermissionFilter"
+          class="org.jahia.modules.sitesettings.render.SettingsComponentPermissionFilter">
+        <property name="priority" value="22"/>
+        <property name="description"
+                  value="Renders a settings component only for a caller holding an administration permission on the main resource"/>
+        <property name="applyOnNodeTypes"
+                  value="jnt:siteSettingsManageUsers,jnt:siteSettingsManageGroups,jnt:siteSettingsManageModules,jnt:siteSettingsManagePageModels,jnt:siteSettingsWcagCompliance,jnt:siteSettingsHtmlFiltering,jnt:siteSettingsManageLanguages"/>
+        <property name="requiredPermissions" value="site-admin,admin"/>
+    </bean>
 </beans>


### PR DESCRIPTION
Backport of #240 (development line) onto `8_7_x`, for the 8.7.1 release — requested on that PR.

## Summary

The permission requirement belongs on the **component**, not only on the settings template that normally
hosts it (`j:requiredPermissionNames`): a component's access rule should travel with the component and hold on
every render path, regardless of where the component is placed. This module's settings screens are ordinary,
instantiable content types, so the requirement is made a property of each component.

## Change

A render filter (`SettingsComponentPermissionFilter`, priority 21.5) applied on this line's **seven**
`jnt:siteSettings*` node types. When the caller holds none of the accepted permissions it returns an empty
fragment — core's own semantics in `TemplatePermissionCheckFilter`. Because `WebflowAction` re-enters the
render chain for each webflow POST, every transition is covered too, not just the initial GET.

**The check is evaluated on the render's MAIN RESOURCE, not on the component node.** The component node of a
legitimate settings screen lives inside the module (`/modules/...`), where a site-scoped administrator holds
nothing; the main resource is the site (site-settings route) or the global settings node
(server-administration route), which is what each administrator role is granted on. Checking the component
node — the obvious implementation — would refuse real site administrators.

Either `site-admin` or `admin` is accepted, since these screens are reached from both administration routes.
Both are core permissions (`root-permissions.xml`). The finer per-screen permissions are contributed by this
module's own `permissions.xml` and resolve to `false` where they are not registered on an instance, which would
fail closed for administrators too; the finer requirement still applies on the administration route via the
template, so this is an additional condition and never a replacement.

## Differences from the development-line PR

**Seven node types, not six.** This line still has `jnt:siteSettingsManageLanguages`, which no longer exists
as a settings component on the development line, so it is gated here as well. Two of the seven are flow-backed
(`ManageUsers`, `ManageGroups`); the other five are JSP screens, included because the requirement belongs on
the component either way.

**A one-block `pom.xml` change is required, and it is load-bearing.** The filter is registered via OSGi
Declarative Services, matching the development line — but this line's parent (`jahia-modules` 8.1.0.0) does not
switch on bnd's DS annotation scanning. Without `<_dsannotations>*</_dsannotations>` an `@Component` class
compiles and ships while emitting no `OSGI-INF` descriptor and no `Service-Component` header, so the component
never registers and the filter silently does not run — no error, green build. The instruction makes the
descriptor deterministic regardless of the parent. Measured on `tags`, whose parent is the older 8.0.1.0:
without the instruction the jar carried the compiled `@Component` and no descriptor; with it, the descriptor is
present. The block can be dropped if this line's parent is ever bumped to >= 8.1.7.0.

No Cypress spec is included: this line carries no Cypress project, matching the precedent set on #249 for this
branch ("drop the ported specs — this line carries no Cypress project"). This line also has no `.chachalog`
directory or workflow, so no changelog fragment is added.

## Verification — what was and was not done

Please treat CI as the compile gate here. Stated plainly:

- **This line does not build in my environment**, so I could neither compile nor deploy-verify the backport.
  `jahia-maven-plugin:5.18:dependencies` fails with `NoClassDefFoundError: org/jahia/utils/osgi/parsers/ParsingContext`,
  and the pinned `nodeVersion v14.16.0` is no longer downloadable (404). Neither is related to this change.
- **Import compatibility was checked statically** against the line itself rather than assumed: the filter uses
  `org.apache.commons.lang.StringUtils` (commons-lang 2), which is what this line's existing
  `UsersFlowHandler` / `ManageGroupsFlowHandler` import — not `lang3` — and `RenderContext` is already used by
  those same classes. The remaining API (`AbstractFilter`, `RenderChain`, `Resource`,
  `JCRNodeWrapper.hasPermission`) predates this line by several major versions.
- **The mechanism itself is verified on the development line**, where the identical filter was measured
  registering at priority 22 — since restated as 21.5, which does not change the resulting order — and
  enforcing the permission per caller, with read controls confirming the negatives are permission decisions
  rather than unreadable nodes.

So the intent and the mechanism are verified; the *build* of this particular line is not, and I would rather
say so than imply otherwise.

**The one check I could not run has since been made, from CI's own artifact.** The `build-artifacts` of the
run on this branch contains `siteSettings-8.7.0.jar` with:

```
OSGI-INF/org.jahia.modules.sitesettings.render.SettingsComponentPermissionFilter.xml   (418 B)
Service-Component: OSGI-INF/org.jahia.modules.sitesettings.render.SettingsComponentPermissionFilter.xml
```

and the descriptor declares the component `immediate="true"` with `activate="activate"`, providing
`org.jahia.services.render.filter.RenderFilter`. So the `pom.xml` addition does reach this line's older parent
and the component will register — that was the only thing this backport was actually waiting on. Karaf
`scr:list` remains the runtime equivalent if anyone wants to confirm it on a deployed instance.

Beyond that: a render of one settings screen as a site administrator (must still work) and as an ordinary
editor (must render nothing) is the whole functional check.

## Notes

- Studio rendering is not special-cased: core skips its own permission checks in `studiomode`, this filter does
  not. A template developer previewing one of these components in studio without an administration permission
  will get an empty fragment.
- `equals`/`hashCode` are deliberately not overridden: `AbstractFilter` defines equality as
  (concrete class, priority), which is the key `RenderService.addFilter` uses to replace an already-registered
  filter. Widening it would break that re-registration.

- Placement is deliberately left unconstrained in the nodetype definitions. The condition holds wherever the
  component renders, so a definition-level restriction would be belt-and-braces rather than the load-bearing
  control. Recorded here so it does not read as an oversight.
- Priority is 21.5, not 22. An exact 22 tied with core's `templateNodeFilter` (22.0); `AbstractFilter` breaks
  such a tie on the class name, so the resulting order held by an accident of package naming. 21.5 states the
  intended slot — immediately after core's permission check at 21, clear of the 22.x template band — directly.
  No behavioural change: 22 already ordered ahead of `templateNodeFilter`.
