### PR TITLE
fix(ci): unbreak the static analysis on the 8_7_x line

### DIFF
--- a/.github/workflows/on-code-change.yml
+++ b/.github/workflows/on-code-change.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: Jahia/jahia-modules-action/static-analysis@v2
         with:
-          node_version: 12
+          node_version: 16
           auditci_level: high
 
   build:

--- a/package.json
+++ b/package.json
@@ -29,7 +29,9 @@
     }
   },
   "resolutions": {
-    "scss-tokenizer": "^0.4.2"
+    "scss-tokenizer": "^0.4.2",
+    "file-loader/loader-utils": "^2.0.4",
+    "loader-utils/json5": "^2.2.3"
   },
   "dependencies": {
     "@jahia/moonstone": "^1.5.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4145,7 +4145,12 @@ json5@^1.0.1:
   dependencies:
     minimist "^1.2.0"
 
-json5@^2.1.2, json5@^2.2.1:
+json5@^2.1.2, json5@^2.2.3:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.3.tgz#78cd6f1a19bdc12b73db5ad0c61efd66c1e29283"
+  integrity sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==
+
+json5@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.1.tgz#655d50ed1e6f95ad1a3caababd2b0efda10b395c"
   integrity sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==
@@ -4254,10 +4259,10 @@ loader-utils@^1.2.3:
     emojis-list "^3.0.0"
     json5 "^1.0.1"
 
-loader-utils@^2.0.0:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-2.0.2.tgz#d6e3b4fb81870721ae4e0868ab11dd638368c129"
-  integrity sha512-TM57VeHptv569d/GKh6TAYdzKblwDNiumOdkFnejjD0XwTH87K90w3O7AiJRqdQoXygvi1VQTJTLGhJl7WqA7A==
+loader-utils@^2.0.0, loader-utils@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-2.0.4.tgz#8b5cb38b5c34a9a018ee1fc0e6a066d1dfcc528c"
+  integrity sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==
   dependencies:
     big.js "^5.2.2"
     emojis-list "^3.0.0"


### PR DESCRIPTION
## What

Two commits, both on `8_7_x`:

1. `.github/workflows/on-code-change.yml` — the static-analysis job moves from Node 12 to Node 16.
2. `package.json` / `yarn.lock` — two scoped `resolutions` pull the `file-loader` chain past its published advisories.

## Why

The `Static Analysis (linting, vulns)` check fails on **every** open pull request targeting `8_7_x` — #244, #249 and #251 — and the failure has nothing to do with what any of them change.

The job installs the scanner unpinned (`npm install -g audit-ci`), so it picks up the current `audit-ci@7.1.0`, whose `engines` field requires Node `>=16`. Loaded by Node 12, it died before scanning anything:

```
SyntaxError: Unexpected token '?'
  at Loader.moduleStrategy (internal/modules/esm/translators.js:140:18)
```

**That crash was hiding real findings.** With Node 16, the scanner runs, and reports one critical and three high advisories on a single chain — `file-loader > loader-utils`, and the `json5` beneath it. As long as Node 12 was pinned, this line was never scanned: the red check said "the tool is broken", not "the dependencies are clean", and nothing in the annotation let a reader tell the difference.

| Advisory | Package | Resolved before | Patched in |
|---|---|---|---|
| GHSA-76p3-8jx3-jpfq (critical) | `loader-utils` | 2.0.2 | 2.0.3 |
| GHSA-3rfm-jhwj-7488 (high) | `loader-utils` | 2.0.2 | 2.0.4 |
| GHSA-hhq3-ff78-jv3g (high) | `loader-utils` | 2.0.2 | 2.0.4 |
| GHSA-9c47-m6qq-7p4h (high) | `json5` | 2.2.1 | 2.2.2 |

## Choices worth knowing

**Node 16, not the 18 the main line uses.** It is the lowest version that satisfies the installed tool, so the eslint half of the job — which already passes — keeps running close to the toolchain this maintenance line was built against.

**`audit-ci` stays unpinned.** Pinning would freeze a vulnerability scanner, which is worse than following it. The cost is that the same break returns the day `audit-ci` raises its floor again.

**The resolutions are scoped to a path, not to a bare package name.** `loader-utils` and `json5` each appear twice in this tree: `css-loader`, `eslint-config-xo` and `eslint-loader` ask for `loader-utils@^1.2.3` and `json5@^1.0.1`. A bare resolution would drag those onto a major they were never written against, to fix a chain the module audit does not even look at — it runs `--skip-dev`, and those are development dependencies.

**The json5 key is `loader-utils/json5`, not `file-loader/loader-utils/json5`.** The deeper path was tried first and changed nothing: `loader-utils` asks for `^2.1.2`, and yarn satisfied that from the existing 2.2.1 entry.

## Checking it

Measured locally on the regenerated lockfile, with the same scope the job uses:

```
yarn audit --level high --groups dependencies
  before: 8 moderate | 1 high      (after the Node fix alone)
  after:  8 moderate
```

The eight moderate advisories are left alone — the job gates on `high`.

The check going green here is the real test. #244, #249 and #251 should follow once this lands and they are rebuilt.