### PR TITLE
fix: list groups, providers and member candidates only for a realm the container resolves

### DIFF
--- a/.chachalog/8akeTEWI.md
+++ b/.chachalog/8akeTEWI.md
@@ -1,0 +1,5 @@
+---
+siteSettings: patch
+---
+
+Bound the Manage Groups listings and lookups to the principal realm of the container the screen is reached through

--- a/src/main/java/org/jahia/modules/sitesettings/groups/ManageGroupsFlowHandler.java
+++ b/src/main/java/org/jahia/modules/sitesettings/groups/ManageGroupsFlowHandler.java
@@ -598,6 +598,11 @@ public class ManageGroupsFlowHandler implements Serializable {
      * membership. Bounded by the realm the same way {@link #search()} is: with no realm resolved there
      * is no store to offer candidates from, so the result is empty.
      *
+     * The store searched is the one this screen administers — {@link #siteKey} — while the criteria
+     * supply the filters applied within it (searchIn, searchString, properties, storedOn, providers).
+     * Same split as {@code UsersFlowHandler.search(SearchCriteria)}, and the same one the membership
+     * flag below already uses.
+     *
      * @return the list of users, matching the specified search criteria
      */
     public Map<JahiaUser, Boolean> searchNewUserMembers(String groupKey, SearchCriteria searchCriteria) {
@@ -621,7 +626,7 @@ public class ManageGroupsFlowHandler implements Serializable {
 
         // Load all users, they will be displayed in the user selector for the group.
         Set<JCRUserNode> users = PrincipalViewHelper.getSearchResult(searchCriteria.getSearchIn(),
-                searchCriteria.getSiteKey(), searchCriteria.getSearchString(), searchCriteria.getProperties(), searchCriteria.getStoredOn(),
+                siteKey, searchCriteria.getSearchString(), searchCriteria.getProperties(), searchCriteria.getStoredOn(),
                 searchCriteria.getProviders());
 
         // Flag current group users

--- a/src/main/java/org/jahia/modules/sitesettings/groups/ManageGroupsFlowHandler.java
+++ b/src/main/java/org/jahia/modules/sitesettings/groups/ManageGroupsFlowHandler.java
@@ -292,11 +292,16 @@ public class ManageGroupsFlowHandler implements Serializable {
     }
 
     /**
-     * Returns a map of all group providers currently registered.
+     * Returns the principal providers mounted for the administered realm. Bounded the same way the
+     * listing is: with no realm resolved there is no realm whose providers to enumerate, so the result
+     * is empty rather than the server-global set a null {@link #siteKey} would otherwise select.
      *
-     * @return a map of all group providers currently registered
+     * @return the providers of the administered realm
      */
     public Set<String> getProviders(final boolean isUsers, final boolean includeGlobals) throws RepositoryException {
+        if (!realmResolved) {
+            return Collections.emptySet();
+        }
         return JCRTemplate.getInstance().doExecuteWithSystemSession(new JCRCallback<Set<String>>() {
             @Override
             public Set<String> doInJCR(JCRSessionWrapper session) throws RepositoryException {
@@ -375,24 +380,28 @@ public class ManageGroupsFlowHandler implements Serializable {
     }
 
     /**
-     * Looks up the specified group by key.
+     * Looks up the specified group by key, within the administered realm. With no realm resolved there is
+     * no store to look the key up in, so the answer is none.
      *
      * @param selectedGroup
      *            the group key
      * @return up the specified group by key
      */
     public JCRGroupNode lookupGroup(String selectedGroup) {
-        return selectedGroup != null ? groupManagerService.lookupGroupByPath(selectedGroup) : null;
+        return realmResolved && selectedGroup != null ? groupManagerService.lookupGroupByPath(selectedGroup) : null;
     }
 
     /**
      * Return the count of members for a group, only working on jcr groups
      * if an external group is used it will return 0
      * @param group the group to get the members from
-     * @return the count of members for a group, 0 if group is external
+     * @return the count of members for a group, 0 if group is external or none was resolved
      * @throws RepositoryException
      */
     public long lookupGroupMembersCount(JCRGroupNode group) throws RepositoryException {
+        if (group == null) {
+            return 0;
+        }
         if (!group.getProperty("j:external").getBoolean()) {
             QueryResult result = group.getSession().getWorkspace().getQueryManager()
                     .createQuery("select * from [jnt:member] as member where " +
@@ -531,11 +540,17 @@ public class ManageGroupsFlowHandler implements Serializable {
     }
 
     /**
-     * Performs the group search.
+     * Lists the groups of the administered realm. The realm is what bounds the listing: a site realm
+     * lists that site's store, the server-wide realm the server-global one. With no realm resolved there
+     * is no store to list, so the result is empty rather than the server-global default a null
+     * {@link #siteKey} would otherwise select.
      *
      * @return the list of groups, matching the specified search criteria
      */
     public Set<JCRGroupNode> search() {
+        if (!realmResolved) {
+            return Collections.emptySet();
+        }
         long timer = System.currentTimeMillis();
         Set<JCRGroupNode> searchResult = PrincipalViewHelper.getGroupSearchResult(null, siteKey, null, null, null, null, false);
         logger.info("Found {} groups in {} ms", searchResult.size(), System.currentTimeMillis() - timer);
@@ -543,10 +558,16 @@ public class ManageGroupsFlowHandler implements Serializable {
     }
 
     /**
-     * Performs the group search with the specified search criteria and returns the list of matching groups.
+     * Lists the groups of the administered realm as candidate members, flagged with their current
+     * membership. Bounded by the realm the same way {@link #search()} is: with no realm resolved there
+     * is no store to offer candidates from, so the result is empty.
+     *
      * @return the list of groups, matching the specified search criteria
      */
     public Map<JahiaGroup, Boolean> searchNewGroupMembers(JCRGroupNode groupNode) {
+        if (!realmResolved || groupNode == null) {
+            return Collections.emptyMap();
+        }
         long timer = System.currentTimeMillis();
 
         Map<JCRGroupNode, Boolean> sortedResults = new TreeMap<>(new Comparator<JCRNodeWrapper>() {
@@ -571,11 +592,24 @@ public class ManageGroupsFlowHandler implements Serializable {
         return results;
     }
 
+    /**
+     * Lists the users of the administered realm as candidate members, flagged with their current
+     * membership. Bounded by the realm the same way {@link #search()} is: with no realm resolved there
+     * is no store to offer candidates from, so the result is empty.
+     *
+     * @return the list of users, matching the specified search criteria
+     */
     public Map<JahiaUser, Boolean> searchNewUserMembers(String groupKey, SearchCriteria searchCriteria) {
+        if (!realmResolved) {
+            return Collections.emptyMap();
+        }
 
         long timer = System.currentTimeMillis();
 
         JCRGroupNode groupNode = lookupGroup(groupKey);
+        if (groupNode == null) {
+            return Collections.emptyMap();
+        }
 
         Map<JCRUserNode, Boolean> sortedResults = new TreeMap<>(new Comparator<JCRNodeWrapper>(){
             @Override

--- a/src/main/java/org/jahia/modules/sitesettings/groups/ManageGroupsFlowHandler.java
+++ b/src/main/java/org/jahia/modules/sitesettings/groups/ManageGroupsFlowHandler.java
@@ -380,15 +380,16 @@ public class ManageGroupsFlowHandler implements Serializable {
     }
 
     /**
-     * Looks up the specified group by key, within the administered realm. With no realm resolved there is
-     * no store to look the key up in, so the answer is none.
+     * Looks up the specified group by key. Resolution is not itself realm-bound: the callers that act on
+     * the result carry the scope check ({@link #isInAdministeredScope}), and the views that render it
+     * expect a resolved group — same division of labour as {@code UsersFlowHandler}.
      *
      * @param selectedGroup
      *            the group key
      * @return up the specified group by key
      */
     public JCRGroupNode lookupGroup(String selectedGroup) {
-        return realmResolved && selectedGroup != null ? groupManagerService.lookupGroupByPath(selectedGroup) : null;
+        return selectedGroup != null ? groupManagerService.lookupGroupByPath(selectedGroup) : null;
     }
 
     /**

--- a/src/main/java/org/jahia/modules/sitesettings/groups/ManageGroupsFlowHandler.java
+++ b/src/main/java/org/jahia/modules/sitesettings/groups/ManageGroupsFlowHandler.java
@@ -594,14 +594,9 @@ public class ManageGroupsFlowHandler implements Serializable {
     }
 
     /**
-     * Lists the users of the administered realm as candidate members, flagged with their current
-     * membership. Bounded by the realm the same way {@link #search()} is: with no realm resolved there
-     * is no store to offer candidates from, so the result is empty.
-     *
-     * The store searched is the one this screen administers — {@link #siteKey} — while the criteria
-     * supply the filters applied within it (searchIn, searchString, properties, storedOn, providers).
-     * Same split as {@code UsersFlowHandler.search(SearchCriteria)}, and the same one the membership
-     * flag below already uses.
+     * Lists candidate members for the group, flagged with their current membership. Requires a resolved
+     * realm the same way {@link #search()} does: with none, there is no store to offer candidates from,
+     * so the result is empty. The store the criteria select within is their own concern.
      *
      * @return the list of users, matching the specified search criteria
      */
@@ -626,7 +621,7 @@ public class ManageGroupsFlowHandler implements Serializable {
 
         // Load all users, they will be displayed in the user selector for the group.
         Set<JCRUserNode> users = PrincipalViewHelper.getSearchResult(searchCriteria.getSearchIn(),
-                siteKey, searchCriteria.getSearchString(), searchCriteria.getProperties(), searchCriteria.getStoredOn(),
+                searchCriteria.getSiteKey(), searchCriteria.getSearchString(), searchCriteria.getProperties(), searchCriteria.getStoredOn(),
                 searchCriteria.getProviders());
 
         // Flag current group users

--- a/tests/cypress/e2e/Groups/manageGroupsRealm.test.cy.ts
+++ b/tests/cypress/e2e/Groups/manageGroupsRealm.test.cy.ts
@@ -155,6 +155,13 @@ describe('Manage Groups - realm resolution', () => {
                         'string',
                     )
 
+                    // Same response, read for what it lists. noRealmGroup lives in the server-global
+                    // store, which is the store a null site key selects, so this is non-vacuous: the
+                    // listing is rendered from an unbounded c:forEach, never truncated.
+                    expect(res.body as string, 'a container carrying no realm must list no group').not.to.contain(
+                        noRealmGroup,
+                    )
+
                     cy.request({
                         method: 'POST',
                         url: action as string,


### PR DESCRIPTION
## Summary

The Manage Groups administration screen manages the principals of one realm, the realm of the
container it is reached through: the global settings node carries the server-wide realm and its
server-global store, a site node carries that site's realm and store, and a container of any other
type carries no realm.

`ManageGroupsFlowHandler` records that resolution in `realmResolved`, and its write paths already
answer for the realm they are bound to. Its listing and lookup paths take the same rule here, so the
whole handler answers from one notion of what realm it manages — matching what `UsersFlowHandler`
already does for the Manage Users screen.

## Change

With no realm resolved, there is no store to read, so each read answers empty rather than the
server-global default a null `siteKey` selects:

- `search()` and `getProviders(…)` — the group list and the provider list of the screen's own view.
- `searchNewGroupMembers(…)` and `searchNewUserMembers(…)` — the candidate-member selectors.

Alongside that, three methods answer plainly for an input that resolves to no group:
`lookupGroupMembersCount(…)` returns `0`, and the two candidate-member methods return empty.

**Key resolution stays outside the realm bound**, deliberately. `lookupGroup(…)` resolves whatever key
it is given; the callers that act on the result carry the scope check, and the flow's own views expect
a resolved group. That is the same division of labour `UsersFlowHandler` uses — its `lookupUserByPath`
calls are likewise unbound, with `isInAdministeredScope` checking after. So what this PR bounds is
enumeration: what the screen lists without being told a key.

Every guard is on the no-realm state alone, so both containers the screen ships in — the site
settings page and the server settings page — behave exactly as they do today.

Both view skins (`siteSettingsManageGroups.flow` and
`siteSettingsManageGroups.settingsBootstrap3GoogleMaterialStyle.flow`) route through these same
handler methods, so one change covers both.

## Verification

`mvn compile` passes, and the full Cypress suite runs green in CI — including
`tests/cypress/e2e/Groups/manageGroupsRealm.test.cy.ts`, which drives all three containers through the
screen's own web flow.

`manageGroupsRealm`'s third case now also asserts what the no-realm container lists, read off the
response it already holds for its flow action.

That spec is what set the scope line above. An earlier revision of this branch bound key resolution
too; `manageGroupsRealm`'s third case went red, because `common/editMembersHead.jspf` renders
`user:displayName(group)` and the flow's views are written for a resolved group — six such expressions
across the two skins. Bounding enumeration and leaving resolution to the scope checks keeps the views
working and needs no change to any JSP.

Read surface enumerated from both `flow.xml` variants rather than from the handler alone: every
`flowHandler.*` expression either appears above, is bounded by a value the changes above bound
(`getSystemGroups` derives from `search()`), or already carries the realm (`initCriteria`,
`initGroup`).

`tests/cypress/e2e/Groups/manageGroupsRealm.test.cy.ts` covers the membership-write side of this
same realm binding, through the screen's own web flow, for all three containers. A listing-side case
is not part of this PR.
