### PR TITLE
fix: list groups, providers and member candidates only for a realm the container resolves

### DIFF
--- a/src/main/java/org/jahia/modules/sitesettings/groups/ManageGroupsFlowHandler.java
+++ b/src/main/java/org/jahia/modules/sitesettings/groups/ManageGroupsFlowHandler.java
@@ -290,11 +290,16 @@ public class ManageGroupsFlowHandler implements Serializable {
     }
 
     /**
-     * Returns a map of all group providers currently registered.
-     * 
-     * @return a map of all group providers currently registered
+     * Returns the principal providers mounted for the administered realm. Bounded the same way the
+     * listing is: with no realm resolved there is no realm whose providers to enumerate, so the result
+     * is empty rather than the server-global set a null {@link #siteKey} would otherwise select.
+     *
+     * @return the providers of the administered realm
      */
     public Set<String> getProviders(final boolean isUsers, final boolean includeGlobals) throws RepositoryException {
+        if (!realmResolved) {
+            return Collections.emptySet();
+        }
         return JCRTemplate.getInstance().doExecuteWithSystemSession(new JCRCallback<Set<String>>() {
             @Override
             public Set<String> doInJCR(JCRSessionWrapper session) throws RepositoryException {
@@ -373,24 +378,28 @@ public class ManageGroupsFlowHandler implements Serializable {
     }
 
     /**
-     * Looks up the specified group by key.
-     * 
+     * Looks up the specified group by key, within the administered realm. With no realm resolved there is
+     * no store to look the key up in, so the answer is none.
+     *
      * @param selectedGroup
      *            the group key
      * @return up the specified group by key
      */
     public JCRGroupNode lookupGroup(String selectedGroup) {
-        return selectedGroup != null ? groupManagerService.lookupGroupByPath(selectedGroup) : null;
+        return realmResolved && selectedGroup != null ? groupManagerService.lookupGroupByPath(selectedGroup) : null;
     }
 
     /**
      * Return the count of members for a group, only working on jcr groups
      * if an external group is used it will return 0
      * @param group the group to get the members from
-     * @return the count of members for a group, 0 if group is external
+     * @return the count of members for a group, 0 if group is external or none was resolved
      * @throws RepositoryException
      */
     public long lookupGroupMembersCount(JCRGroupNode group) throws RepositoryException {
+        if (group == null) {
+            return 0;
+        }
         if (!group.getProperty("j:external").getBoolean()) {
             QueryResult result = group.getSession().getWorkspace().getQueryManager()
                     .createQuery("select * from [jnt:member] as member where " +
@@ -529,11 +538,17 @@ public class ManageGroupsFlowHandler implements Serializable {
     }
 
     /**
-     * Performs the group search.
+     * Lists the groups of the administered realm. The realm is what bounds the listing: a site realm
+     * lists that site's store, the server-wide realm the server-global one. With no realm resolved there
+     * is no store to list, so the result is empty rather than the server-global default a null
+     * {@link #siteKey} would otherwise select.
      *
      * @return the list of groups, matching the specified search criteria
      */
     public Set<JCRGroupNode> search() {
+        if (!realmResolved) {
+            return Collections.emptySet();
+        }
         long timer = System.currentTimeMillis();
         Set<JCRGroupNode> searchResult = PrincipalViewHelper.getGroupSearchResult(null, siteKey, null, null, null, null, false);
         logger.info("Found {} groups in {} ms", searchResult.size(), System.currentTimeMillis() - timer);
@@ -541,10 +556,16 @@ public class ManageGroupsFlowHandler implements Serializable {
     }
 
     /**
-     * Performs the group search with the specified search criteria and returns the list of matching groups.
+     * Lists the groups of the administered realm as candidate members, flagged with their current
+     * membership. Bounded by the realm the same way {@link #search()} is: with no realm resolved there
+     * is no store to offer candidates from, so the result is empty.
+     *
      * @return the list of groups, matching the specified search criteria
      */
     public Map<JahiaGroup, Boolean> searchNewGroupMembers(JCRGroupNode groupNode) {
+        if (!realmResolved || groupNode == null) {
+            return Collections.emptyMap();
+        }
         long timer = System.currentTimeMillis();
 
         Map<JCRGroupNode, Boolean> sortedResults = new TreeMap<>(new Comparator<JCRNodeWrapper>() {
@@ -569,11 +590,24 @@ public class ManageGroupsFlowHandler implements Serializable {
         return results;
     }
 
+    /**
+     * Lists the users of the administered realm as candidate members, flagged with their current
+     * membership. Bounded by the realm the same way {@link #search()} is: with no realm resolved there
+     * is no store to offer candidates from, so the result is empty.
+     *
+     * @return the list of users, matching the specified search criteria
+     */
     public Map<JahiaUser, Boolean> searchNewUserMembers(String groupKey, SearchCriteria searchCriteria) {
+        if (!realmResolved) {
+            return Collections.emptyMap();
+        }
 
         long timer = System.currentTimeMillis();
 
         JCRGroupNode groupNode = lookupGroup(groupKey);
+        if (groupNode == null) {
+            return Collections.emptyMap();
+        }
 
         Map<JCRUserNode, Boolean> sortedResults = new TreeMap<>(new Comparator<JCRNodeWrapper>(){
             @Override

--- a/src/main/java/org/jahia/modules/sitesettings/groups/ManageGroupsFlowHandler.java
+++ b/src/main/java/org/jahia/modules/sitesettings/groups/ManageGroupsFlowHandler.java
@@ -378,15 +378,16 @@ public class ManageGroupsFlowHandler implements Serializable {
     }
 
     /**
-     * Looks up the specified group by key, within the administered realm. With no realm resolved there is
-     * no store to look the key up in, so the answer is none.
+     * Looks up the specified group by key. Resolution is not itself realm-bound: the callers that act on
+     * the result carry the scope check ({@link #isInAdministeredScope}), and the views that render it
+     * expect a resolved group — same division of labour as {@code UsersFlowHandler}.
      *
      * @param selectedGroup
      *            the group key
      * @return up the specified group by key
      */
     public JCRGroupNode lookupGroup(String selectedGroup) {
-        return realmResolved && selectedGroup != null ? groupManagerService.lookupGroupByPath(selectedGroup) : null;
+        return selectedGroup != null ? groupManagerService.lookupGroupByPath(selectedGroup) : null;
     }
 
     /**

--- a/src/main/java/org/jahia/modules/sitesettings/groups/ManageGroupsFlowHandler.java
+++ b/src/main/java/org/jahia/modules/sitesettings/groups/ManageGroupsFlowHandler.java
@@ -596,6 +596,11 @@ public class ManageGroupsFlowHandler implements Serializable {
      * membership. Bounded by the realm the same way {@link #search()} is: with no realm resolved there
      * is no store to offer candidates from, so the result is empty.
      *
+     * The store searched is the one this screen administers — {@link #siteKey} — while the criteria
+     * supply the filters applied within it (searchIn, searchString, properties, storedOn, providers).
+     * Same split as {@code UsersFlowHandler.search(SearchCriteria)}, and the same one the membership
+     * flag below already uses.
+     *
      * @return the list of users, matching the specified search criteria
      */
     public Map<JahiaUser, Boolean> searchNewUserMembers(String groupKey, SearchCriteria searchCriteria) {
@@ -618,7 +623,7 @@ public class ManageGroupsFlowHandler implements Serializable {
         });
 
         Set<JCRUserNode> users = PrincipalViewHelper.getSearchResult(searchCriteria.getSearchIn(),
-                searchCriteria.getSiteKey(), searchCriteria.getSearchString(), searchCriteria.getProperties(), searchCriteria.getStoredOn(),
+                siteKey, searchCriteria.getSearchString(), searchCriteria.getProperties(), searchCriteria.getStoredOn(),
                 searchCriteria.getProviders());
 
         String groupName = groupNode.getName();

--- a/src/main/java/org/jahia/modules/sitesettings/groups/ManageGroupsFlowHandler.java
+++ b/src/main/java/org/jahia/modules/sitesettings/groups/ManageGroupsFlowHandler.java
@@ -592,14 +592,9 @@ public class ManageGroupsFlowHandler implements Serializable {
     }
 
     /**
-     * Lists the users of the administered realm as candidate members, flagged with their current
-     * membership. Bounded by the realm the same way {@link #search()} is: with no realm resolved there
-     * is no store to offer candidates from, so the result is empty.
-     *
-     * The store searched is the one this screen administers — {@link #siteKey} — while the criteria
-     * supply the filters applied within it (searchIn, searchString, properties, storedOn, providers).
-     * Same split as {@code UsersFlowHandler.search(SearchCriteria)}, and the same one the membership
-     * flag below already uses.
+     * Lists candidate members for the group, flagged with their current membership. Requires a resolved
+     * realm the same way {@link #search()} does: with none, there is no store to offer candidates from,
+     * so the result is empty. The store the criteria select within is their own concern.
      *
      * @return the list of users, matching the specified search criteria
      */
@@ -623,7 +618,7 @@ public class ManageGroupsFlowHandler implements Serializable {
         });
 
         Set<JCRUserNode> users = PrincipalViewHelper.getSearchResult(searchCriteria.getSearchIn(),
-                siteKey, searchCriteria.getSearchString(), searchCriteria.getProperties(), searchCriteria.getStoredOn(),
+                searchCriteria.getSiteKey(), searchCriteria.getSearchString(), searchCriteria.getProperties(), searchCriteria.getStoredOn(),
                 searchCriteria.getProviders());
 
         String groupName = groupNode.getName();


### PR DESCRIPTION
Companion to #259 for the 8.7.1 milestone, so both lines carry the same rule.

**Stacked on #249** — this targets `audit/fix-settings-screen-realm-8_7_x`, not `8_7_x`, because it
builds on the handler shape that PR introduces on this line. Merge #249 first and GitHub retargets
this one onto `8_7_x` automatically.

## Summary

The Manage Groups administration screen manages the principals of one realm, the realm of the
container it is reached through: the global settings node carries the server-wide realm and its
server-global store, a site node carries that site's realm and store, and a container of any other
type carries no realm.

`ManageGroupsFlowHandler` records that resolution in `realmResolved`, and #249 brings the write paths
that answer for the realm they are bound to. Its listing and lookup paths take the same rule here, so
the whole handler answers from one notion of what realm it manages — matching what `UsersFlowHandler`
already does on this line for the Manage Users screen.

## Change

One cherry-pick of `b20e7b3` from #259. With no realm resolved, there is no store to read, so each
read answers empty rather than the server-global default a null `siteKey` selects:

- `search()` and `getProviders(…)` — the group list and the provider list of the screen's own view.
- `searchNewGroupMembers(…)` and `searchNewUserMembers(…)` — the candidate-member selectors.

Alongside that, three methods answer plainly for an input that resolves to no group:
`lookupGroupMembersCount(…)` returns `0`, and the two candidate-member methods return empty.

**Key resolution stays outside the realm bound**, deliberately. `lookupGroup(…)` resolves whatever key
it is given; the callers that act on the result carry the scope check, and the flow's own views expect
a resolved group. That is the same division of labour `UsersFlowHandler` uses — its `lookupUserByPath`
calls are likewise unbound, with `isInAdministeredScope` checking after. So what this PR bounds is
enumeration: what the screen lists without being told a key.

Every guard is on the no-realm state alone, so both containers the screen ships in — the site
settings page and the server settings page — behave exactly as they do today.

Both view skins (`siteSettingsManageGroups.flow` and
`siteSettingsManageGroups.settingsBootstrap3GoogleMaterialStyle.flow`) route through these same
handler methods, so one change covers both.

## How close is this to #259

The Java is the same six guards. The cherry-pick conflicted twice, both times on javadoc only — this
line carries trailing whitespace in the two comment blocks the change rewrites (`getProviders`,
`lookupGroup`) — and was resolved to the new text. No code hunk conflicted.

`#259`'s `.chachalog/` fragment is deliberately not carried: this line has no `.chachalog/` directory
and none of the `chachalog-*` workflows, the same reason `a39f9e1` on #249 dropped the three that
travelled with its own cherry-picks.

## Release notes

Whoever writes the 8.7.1 notes: this is covered by the line already quoted in #249, and with this PR
in, that line needs no qualifier for either screen.

## Verification

`mvn compiler:compile` passes, against the Maven-resolved dependency classpath, with both handler
classes produced.

Note for anyone else building this line on an M-series Mac: the full `mvn compile` cannot run here,
because `frontend-maven-plugin` pins `nodeVersion v14.16.0` and Node publishes no arm64 macOS build
before 16. `mvn compiler:compile` invokes the compiler goal on its own, so the lifecycle never
reaches that plugin — which is enough to check Java on this line without a workaround.

No Cypress specs: this line carries no `tests/` tree at all, matching #249, #244 and #245. The
equivalent change on `main` is covered there by `manageGroupsRealm.test.cy.ts`, green in #259's CI.

That spec is what set the scope line above. An earlier revision of #259 bound key resolution too, and
`manageGroupsRealm`'s third case went red: `common/editMembersHead.jspf` renders
`user:displayName(group)` and the flow's views are written for a resolved group — six such expressions
across the two skins. Bounding enumeration and leaving resolution to the scope checks keeps the views
working and needs no change to any JSP. That correction is carried here as `dd7dcd3`.
